### PR TITLE
Updated post-install-cmd section in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -145,7 +145,7 @@
     },
     "post-install-cmd": [
       "@auto-scripts",
-      "rm -Rf vendor/elasticsearch/elasticsearch/tests/Elasticsearch/Tests",
+      "rm -rf vendor/elasticsearch/elasticsearch/tests/Elasticsearch/Tests",
       "Google\\Task\\Composer::cleanup"
     ],
     "post-update-cmd": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Running `composer install` is breaking in the `post-install-cmd` section due to incorrect flag `-R` passed to the `rm` command. Updated Line #148 in the `post-install-cmd` section in the composer.json with correct flag `-r` for `rm` command.

## Motivation and Context
Since there is no `-R` flag in Linux for `rm` command, the `post-install-cmd` section is breaking up while running composer install in the root directory.

## How To Test This
Run `composer install` in the root directory.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->