### PR TITLE
Support FreeBSD and simplify Windows-checking logic

### DIFF
--- a/public/legacy/Api/V8/Config/services/middlewares.php
+++ b/public/legacy/Api/V8/Config/services/middlewares.php
@@ -24,7 +24,7 @@ return CustomLoader::mergeCustomArray([
         // base dir must exist in entryPoint.php
         $baseDir = $GLOBALS['BASE_DIR'];
 
-        $shouldCheckPermissions = OsHelper::getOS() !== OsHelper::OS_WINDOWS;
+        $shouldCheckPermissions = !OsHelper::isWindows();
 
         $server = new AuthorizationServer(
             new ClientRepository(
@@ -90,7 +90,7 @@ return CustomLoader::mergeCustomArray([
     ResourceServer::class => static function (Container $container) {
         $baseDir = $GLOBALS['BASE_DIR'];
 
-        $shouldCheckPermissions = OsHelper::getOS() !== OsHelper::OS_WINDOWS;
+        $shouldCheckPermissions = !OsHelper::isWindows();
 
         return new ResourceServer(
             new AccessTokenRepository(

--- a/public/legacy/Api/V8/Helper/OsHelper.php
+++ b/public/legacy/Api/V8/Helper/OsHelper.php
@@ -9,6 +9,7 @@ class OsHelper
 {
     const OS_WINDOWS = 'WINDOWS';
     const OS_LINUX = 'LINUX';
+    const OS_FREEBSD = 'FREEBSD';
     const OS_OSX = 'OSX';
 
     /**
@@ -28,8 +29,21 @@ class OsHelper
             case stristr(PHP_OS, 'LINUX'):
                 return self::OS_LINUX;
 
+            case stristr(PHP_OS, 'FREEBSD'):
+                return self::OS_FREEBSD;
+
             default:
                 throw new \RuntimeException('Unable to determine OS');
         }
+    }
+
+    /**
+     * @return boolean
+     *
+     * @throws \RuntimeException When unable to determine OS.
+     */
+    public static function isWindows()
+    {
+        return self::getOS() === self::OS_WINDOWS;
     }
 }


### PR DESCRIPTION
## Description
From what I see, OsHelper::getOS is only used in midelwares.php to
determine whether or not a OS is Windows and therefore permissions
should be checked, so while at it, I add a static method to check
precisely for that.

## Motivation and Context
Without this patch or something similar, the API endpoints fail on
FreeBSD for no good reason.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

