### PR TITLE
Fix #53 - Remove hardcoded dependency to en_us language

### DIFF
--- a/core/backend/Authentication/LegacyHandler/UserHandler.php
+++ b/core/backend/Authentication/LegacyHandler/UserHandler.php
@@ -110,6 +110,20 @@ class UserHandler extends LegacyHandler
     }
 
     /**
+     * Get current language
+     * @return string
+     */
+    public function getCurrentLanguage(): string
+    {
+        $language = $this->getSessionLanguage();
+        if (empty($language)) {
+            $language = $this->getSystemLanguage();
+        }
+
+        return $language ?? 'en_us';
+    }
+
+    /**
      * Get current session language
      * @return string
      */

--- a/core/backend/Process/Service/LineActionDefinitionProvider.php
+++ b/core/backend/Process/Service/LineActionDefinitionProvider.php
@@ -28,9 +28,10 @@
 
 namespace App\Process\Service;
 
+use App\Authentication\LegacyHandler\UserHandler;
+use App\Engine\Service\AclManagerInterface;
 use App\FieldDefinitions\Service\FieldDefinitionsProviderInterface;
 use App\Languages\LegacyHandler\AppListStringsProviderInterface;
-use App\Engine\Service\AclManagerInterface;
 use App\Module\Service\ModuleNameMapperInterface;
 
 class LineActionDefinitionProvider implements LineActionDefinitionProviderInterface
@@ -59,6 +60,10 @@ class LineActionDefinitionProvider implements LineActionDefinitionProviderInterf
      * @var FieldDefinitionsProviderInterface
      */
     private $fieldDefinitionProvider;
+    /**
+     * @var UserHandler
+     */
+    private $userHandler;
 
     /**
      * LineActionDefinitionProvider constructor.
@@ -67,19 +72,22 @@ class LineActionDefinitionProvider implements LineActionDefinitionProviderInterf
      * @param FieldDefinitionsProviderInterface $fieldDefinitionProvider
      * @param ModuleNameMapperInterface $moduleNameMapper
      * @param AppListStringsProviderInterface $appListStringProvider
+     * @param UserHandler $userHandler
      */
     public function __construct(
         array $listViewLineActions,
         AclManagerInterface $aclManager,
         FieldDefinitionsProviderInterface $fieldDefinitionProvider,
         ModuleNameMapperInterface $moduleNameMapper,
-        AppListStringsProviderInterface $appListStringProvider
+        AppListStringsProviderInterface $appListStringProvider,
+        UserHandler $userHandler
     ) {
         $this->listViewLineActions = $listViewLineActions;
         $this->aclManager = $aclManager;
         $this->fieldDefinitionProvider = $fieldDefinitionProvider;
         $this->moduleNameMapper = $moduleNameMapper;
         $this->appListStringProvider = $appListStringProvider;
+        $this->userHandler = $userHandler;
     }
 
     /**
@@ -87,7 +95,9 @@ class LineActionDefinitionProvider implements LineActionDefinitionProviderInterf
      */
     public function getLineActions(string $module): array
     {
-        $appListStringsObject = $this->appListStringProvider->getAppListStrings('en_us');
+        $language = $this->userHandler->getCurrentLanguage();
+
+        $appListStringsObject = $this->appListStringProvider->getAppListStrings($language);
         if ($appListStringsObject !== null) {
             $this->appListStrings = $appListStringsObject->getItems();
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
- Allow disabling `en_us` language
- see #53 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- When the `en_us` language was disabled the user got an error after login
- see #53 


## How To Test This
<!--- Please describe in detail how to test your changes. -->
- Go to app and Login
- go to admin
- install another language pack
- go to languages
- disable `en_us`
- logout
- `en_us` should not show in the languages list
- login with the new language
- the app should work as expected, the ui should should the new language

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->