### PR TITLE
Fix #131 - Cannot login if username is associated with deleted user

### DIFF
--- a/core/modules/Users/Repository/UserRepository.php
+++ b/core/modules/Users/Repository/UserRepository.php
@@ -56,7 +56,9 @@ class UserRepository extends EntityRepository implements UserLoaderInterface
     {
         return $this->createQueryBuilder('u')
             ->where('u.user_name = :user_name')
+            ->andWhere('u.deleted = :deleted')
             ->setParameter('user_name', $username)
+            ->setParameter('deleted', 0)
             ->getQuery()
             ->getOneOrNullResult();
     }


### PR DESCRIPTION
## Description
Added additional condition to prevent 'deleted' records from being included.
#131 

## Motivation and Context
The fix should allow re-use of usernames without duplicate records exceptions being thrown.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->