### PR TITLE
Fixed #155 - Dynamic Dropdown using parent enum labels instead of values

### DIFF
--- a/core/app/core/src/lib/fields/base/base-enum.component.ts
+++ b/core/app/core/src/lib/fields/base/base-enum.component.ts
@@ -283,7 +283,8 @@ export class BaseEnumComponent extends BaseFieldComponent implements OnInit, OnD
         const mappedOptions: { [key: string]: Option[] } = {};
         Object.keys(parentOptions).forEach(key => {
             mappedOptions[key] = childOptions.filter(
-                option => String(option.value).startsWith(parentOptions[key])
+                //Fixed #155 - Dynamic Dropdown in Suitecrm 8 using parent enum Labels instead of values
+                option => String(option.value).startsWith(key)
             );
         });
         return mappedOptions;


### PR DESCRIPTION
- Create child dropdown array with parent enum values (as keys) instead of parent enum labels

<!--- Provide a general summary of your changes in the Title above -->

## Description
While grouping child dependent enum values we need to group by parent enum values instead of parent enum labels

## Motivation and Context
Dependent Dropdown don't work in most cases except the case where parent dropdown labels are the same as dropdown values.
Dependent Dropdowns don't in different languages

## How To Test This
Change the labels of any parent dropdown (for example Case State list  case_state_dom) and dependent dropdown (for example Case Status) will still be working.
While before this fix it was not working

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->