### PR TITLE
Fix #161 - [Legacy] use saved Reminder data in quick edit Calendar

### DIFF
--- a/public/legacy/modules/Calendar/views/view.quickedit.php
+++ b/public/legacy/modules/Calendar/views/view.quickedit.php
@@ -84,6 +84,14 @@ class CalendarViewQuickEdit extends SugarView
         $this->ev->view = "QuickCreate";
         $this->ev->ss = new Sugar_Smarty();
         $this->ev->formName = "CalendarEditView";
+		 //Fix #161 Meetings and Calls quick edit via Calender does not populate correct reminders
+        //Fetch Reminders Data for existing Calls or Meetings and assign to smarty template
+        if (!empty($this->bean->id)) {
+            $this->ev->ss->assign('remindersData', Reminder::loadRemindersData($module, $this->bean->id, false));
+            $this->ev->ss->assign('remindersDataJson', Reminder::loadRemindersDataJson($module, $this->bean->id, false));
+            $this->ev->ss->assign('remindersDefaultValuesDataJson', Reminder::loadRemindersDefaultValuesDataJson());
+            $this->ev->ss->assign('remindersDisabled', json_encode(false));
+        }
         $this->ev->setup($module, $this->bean, $source, $tpl);
         $this->ev->defs['templateMeta']['form']['headerTpl'] = "modules/Calendar/tpls/editHeader.tpl";
         $this->ev->defs['templateMeta']['form']['footerTpl'] = "modules/Calendar/tpls/empty.tpl";


### PR DESCRIPTION
Fetch saved reminder data when opening quick edit view for existing Calls and meetings
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Added code in view.quickedit.php in calendar module to assign reminder data from existing record to smarty variables
Steps to Produce Issue
1. create a meeting/call with reminders different from user default reminder setting for example if email reminder setting is 30 minutes before call default for user change it 15 minutes before for this meeting/call
2. Edit the meeting/call via calendar edit functionality
3. The edit popup opened will show default user reminder settings
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows users to correctly edit a meeting or call via calendar

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. create a meeting/call with reminders different from user default reminder setting for example if email reminder setting is 30 minutes before call default for user change it 15 minutes before (different that default) for this meeting/call
2. Edit the meeting/call via calendar edit functionality
3. The edit popup opened will show correct reminder settings
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->