### PR TITLE
[Legacy] Fix security groups inheriting from parent

### DIFF
--- a/public/legacy/modules/SecurityGroups/SecurityGroup.php
+++ b/public/legacy/modules/SecurityGroups/SecurityGroup.php
@@ -400,8 +400,9 @@ class SecurityGroup extends SecurityGroup_sugar
                 if ((!isset($def['type']) || ($def['type'] == 'relate' && isset($def['id_name'])))
                     && isset($def['module']) && strtolower($def['module']) != 'users'
                 ) {
-                    if (isset($_REQUEST[$def['id_name']])) {
-                        $relate_parent_id = $_REQUEST[$def['id_name']];
+                    $id_name=$def['id_name'];
+                    if (isset($_REQUEST[$id_name])) {
+                        $relate_parent_id = $_REQUEST[$id_name];
                         $relate_parent_type = $def['module'];
 
                         self::inherit_parentQuery(
@@ -411,8 +412,21 @@ class SecurityGroup extends SecurityGroup_sugar
                             $focus_id,
                             $focus_module_dir
                         );
-                    } elseif (isset($_SESSION['portal_id']) && isset($_SESSION[$def['id_name']])) { //soap account
-                        $relate_parent_id = $_SESSION[$def['id_name']];
+                    }
+                    elseif (isset($focus->$id_name)) {
+                        $relate_parent_id = $focus->$id_name;
+                        $relate_parent_type = $def['module'];
+
+                        self::inherit_parentQuery(
+                            $focus,
+                            $relate_parent_type,
+                            $relate_parent_id,
+                            $focus_id,
+                            $focus_module_dir
+                        );
+                    }
+                    elseif (isset($_SESSION['portal_id']) && isset($_SESSION[$id_name])) { //soap account
+                        $relate_parent_id = $_SESSION[$id_name];
                         $relate_parent_type = $def['module'];
 
                         self::inherit_parentQuery(


### PR DESCRIPTION
- In SuiteCRM while saving $_REQUEST variable does not have any id_name
- We need to pick id_name from the record itself

<!--- Provide a general summary of your changes in the Title above -->

## Description
In SecuityGroup.php check also for id_name in focus bean
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Inherit from parent does not work in SuiteCRM 8

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Create a security group add it to an account 
2. Create a contact for the account
3. Security Group for the account will be inherited to the contact while previously in SuiteCRM 8 it did not inherit the security groups

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->