### PR TITLE
FIX #202 CSRFCookieListener: remove RouteMatcherInterface type property to $routeMatcher

### DIFF
--- a/core/backend/Security/CSRFCookieListener.php
+++ b/core/backend/Security/CSRFCookieListener.php
@@ -71,7 +71,7 @@ class CSRFCookieListener
     /**
      * @var RouteMatcherInterface
      */
-    private RouteMatcherInterface $routeMatcher;
+    private $routeMatcher;
 
     /**
      * @param RouteMatcherInterface $routeMatcher


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

REL #202 

When running `bin/console cache:clear` command throws a syntax error.  I Found that [class type property works since PHP 7.4.x](https://stitcher.io/blog/typed-properties-in-php-74) . I test it on a PHP 7.3.x environment and throws the syntax error that it's described at #202 issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->