### PR TITLE
Fix #154 - [Legacy] MySQL Error 1054: missing config.deleted columns

### DIFF
--- a/public/legacy/include/portability/Services/Favorites/FavoritesManagerPort.php
+++ b/public/legacy/include/portability/Services/Favorites/FavoritesManagerPort.php
@@ -130,7 +130,9 @@ class FavoritesManagerPort
         $db = DBManagerFactory::getInstance();
         $userId = $current_user->id ?? null;
 
-        if (empty($db) || empty($userId) || empty($module)) {
+        $excludedModules = ['Home', 'Administration', 'ModuleBuilder'];
+  
+        if (empty($db) || empty($userId) || empty($module) || in_array($module, $excludedModules)) {
             return [];
         }
 


### PR DESCRIPTION

## Description
Some modules don't have an SQL column that the code below expects.

## Motivation and Context
See related Issue #154

Note that I am not sure which modules to add to the **`$excludedModules`** list I created. I know that the **Administration** module is the one causing the FATAL. Other modules could be added here later. I added a few that are "special" modules, without a DB table and a **deleted** column there.

## How To Test This
I am not sure how to trigger it. I came across this in [this Forum thread](https://community.suitecrm.com/t/databse-error-sending-campaign-mails-from-the-email-queue/88564/6). It seems to happen somewhere along the way in the Campaign wizard.

Perhaps the best thing is to first try and reproduce the error, trigger it, and only then try the fix.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
