### PR TITLE
Fixes parent_type relate #196 & #251

### DIFF
--- a/core/app/core/src/lib/fields/dynamic-field/dynamic-field.component.ts
+++ b/core/app/core/src/lib/fields/dynamic-field/dynamic-field.component.ts
@@ -61,9 +61,14 @@ export class DynamicFieldComponent implements OnInit, OnChanges {
     }
 
     get getRelateLink(): string {
-        if (this.field.definition.id_name && this.field.definition.module) {
-            const moduleName = this.moduleNameMapper.toFrontend(this.field.definition.module);
+        let linkModule = this.field.definition.module;
 
+        if (this.field.definition.type_name === 'parent_type') {
+            linkModule = this.record.attributes.parent_type;
+        }
+
+        if (this.field.definition.id_name && linkModule) {
+            const moduleName = this.moduleNameMapper.toFrontend(linkModule);
             return this.navigation.getRecordRouterLink(
                 moduleName,
                 this.record.attributes[this.field.definition.id_name]

--- a/core/app/core/src/lib/services/record/field/group-field.builder.ts
+++ b/core/app/core/src/lib/services/record/field/group-field.builder.ts
@@ -74,6 +74,10 @@ export class GroupFieldBuilder extends FieldBuilder {
                 return;
             }
 
+            if (fieldDefinition && fieldDefinition.type === 'relate' && fieldDefinition.type_name === 'parent_type') {
+                fieldDefinition.module = record.attributes.parent_type;
+            }
+
             const groupViewField = {
                 name: fieldDefinition.name,
                 label: fieldDefinition.vname,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix relate parent_type relate field always having account as linked module

## Description

This Fixes Issues #196 & #251.
The issue is that due to vardefs, the relationship is always set as an account,
if the parent type is not an account the module will be linked wrong in links,
also if the record is edited, the link will be lost.

<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
The fields that are relate parent_type loose their link when modified which is causing issues and causing the CRM to become unusable.
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
Get a module with the parent_type relate field e.g. task and add a record linking to another module that is not account. e.g. lead.
Before fix:
Link in list view goes to account module.
Editing record will loose relationship after save.

After fix:
Link goes to correct module.
Editing keeps correct module after save.
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->