### PR TITLE
Fix #267 - Show activities dropdown labels with regular user

### DIFF
--- a/core/backend/Languages/LegacyHandler/ModStringsHandler.php
+++ b/core/backend/Languages/LegacyHandler/ModStringsHandler.php
@@ -45,7 +45,8 @@ class ModStringsHandler extends LegacyHandler
     protected static $extraModules = [
         'SecurityGroups',
         'Bugs',
-        'History'
+        'History',
+        'Activities'
     ];
 
     /**


### PR DESCRIPTION

## Description
Includes activities modules language file into the extra modules so regular users can see the labels for the dropdown.

## Motivation and Context
Fix issue #267 

## How To Test This
Before change:
regular user cannot see labels in activities subpanel dropdown as seen in #267 

After change:
The issue is fixed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->