### PR TITLE
REL #250 Remove request of bootstrap.min.css

### DIFF
--- a/public/legacy/include/utils/layout_utils.php
+++ b/public/legacy/include/utils/layout_utils.php
@@ -283,7 +283,6 @@ EOHTML;
     }
 
     echo "<title>{$app_strings['LBL_BROWSER_TITLE']}</title>";
-    echo '<link href="themes/'.SugarThemeRegistry::current().'/css/bootstrap.min.css" rel="stylesheet">';
     echo $themeCSS;
     if ($includeJS) {
         $charset = isset($app_strings['LBL_CHARSET']) ? $app_strings['LBL_CHARSET'] : $sugar_config['default_charset'];


### PR DESCRIPTION
The file boostrap.min.css it's missing under the theme css folder.

The file under the css folder of suite8 theme there are the boostrap files uncompressed, and they are imported with the style.scss file of Dawn or Noon styles, so the line of layout_utils.php it's need it.

Issue: #250 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->