### PR TITLE
Fix #321 - Make fields full span

### DIFF
--- a/core/app/core/src/lib/components/field-layout/field-layout.component.html
+++ b/core/app/core/src/lib/components/field-layout/field-layout.component.html
@@ -28,9 +28,7 @@
 <form class="field-layout {{config.mode}}">
     <div [ngClass]="rowClass" *ngFor="let row of fieldGrid; index as i">
 
-        <div *ngFor="let col of row.cols; index as colNumber"
-             [class.field-column-bordered]="row.cols.length > 1 && colNumber < row.cols.length - 1"
-             [ngClass]="colClass">
+        <div *ngFor="let col of row.cols; index as colNumber" [ngClass]="colClass">
 
             <ng-container *ngIf="col.field && col.field.display !== 'none'">
                 <div class="label-container">

--- a/core/app/core/src/lib/components/field-layout/field-layout.component.ts
+++ b/core/app/core/src/lib/components/field-layout/field-layout.component.ts
@@ -119,9 +119,7 @@ export class FieldLayoutComponent extends BaseFieldGridComponent {
                 }
             });
 
-            if (row.cols.length < this.colNumber) {
-                this.fillRow(row);
-            }
+
 
 
             grid.push(row);

--- a/core/app/shell/src/themes/suite8/css/components/_field-layout.scss
+++ b/core/app/shell/src/themes/suite8/css/components/_field-layout.scss
@@ -29,10 +29,6 @@
   color: $midnight-blue;
 }
 
-.field-layout .field-column-bordered {
-  border-right: $nepal-grey solid 0.0625rem;
-}
-
 .field-separation {
   height: 0.1em;
   color: darkgrey;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
Border has been removed in field-layout-component and fillRow(row) because it was dividing row in two seperate columns.
`field-layout .field-column-bordered` class has been removed in field-layout scss because it was not being used anymore. #321 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When set a field to span across both columns, the field is expected spans across both columns in Detail / Edit View.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
In Studio, if you set a field to span across both columns, when you check this in the Detail / Edit View, the field spans across  two column.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->