### PR TITLE
Fix #336 - Lines fix for Crowdin

### DIFF
--- a/public/legacy/include/language/en_us.lang.php
+++ b/public/legacy/include/language/en_us.lang.php
@@ -1127,18 +1127,12 @@ $app_strings = array(
     'LBL_TOUR_SKIP' => 'Skip',
     'LBL_TOUR_BACK' => 'Back',
     'LBL_TOUR_TAKE_TOUR' => 'Take the tour',
-    'LBL_MOREDETAIL' => 'More Detail'
-    /*for 508 compliance fix*/,
-    'LBL_EDIT_INLINE' => 'Edit Inline'
-    /*for 508 compliance fix*/,
-    'LBL_VIEW_INLINE' => 'View'
-    /*for 508 compliance fix*/,
-    'LBL_BASIC_SEARCH' => 'Filter'
-    /*for 508 compliance fix*/,
-    'LBL_Blank' => ' '
-    /*for 508 compliance fix*/,
-    'LBL_ID_FF_ADD' => 'Add'
-    /*for 508 compliance fix*/,
+    'LBL_MOREDETAIL' => 'More Detail' /*for 508 compliance fix*/,
+    'LBL_EDIT_INLINE' => 'Edit Inline' /*for 508 compliance fix*/,
+    'LBL_VIEW_INLINE' => 'View' /*for 508 compliance fix*/,
+    'LBL_BASIC_SEARCH' => 'Filter' /*for 508 compliance fix*/,
+    'LBL_Blank' => ' ' /*for 508 compliance fix*/,
+    'LBL_ID_FF_ADD' => 'Add' /*for 508 compliance fix*/,
     'LBL_ID_FF_ADD_EMAIL' => 'Add Email Address' /*for 508 compliance fix*/,
     'LBL_HIDE_SHOW' => 'Hide/Show' /*for 508 compliance fix*/,
     'LBL_DELETE_INLINE' => 'Delete' /*for 508 compliance fix*/,
@@ -1280,22 +1274,8 @@ $app_strings = array(
     'LBL_EMAIL_ERROR_VIEW_RAW_SOURCE' => 'This information is not available',
     'LBL_EMAIL_ERROR_NO_OUTBOUND' => 'No outgoing mail server specified.',
     'LBL_EMAIL_ERROR_SENDING' => 'Error Sending Email. Please contact your administrator for assistance.',
-    'LBL_EMAIL_FOLDERS' => SugarThemeRegistry::current()->getImage(
-            'icon_email_folder',
-            'align=absmiddle border=0',
-            null,
-            null,
-            '.gif',
-            ''
-        ) . 'Folders',
-    'LBL_EMAIL_FOLDERS_SHORT' => SugarThemeRegistry::current()->getImage(
-        'icon_email_folder',
-        'align=absmiddle border=0',
-        null,
-        null,
-        '.gif',
-        ''
-    ),
+    'LBL_EMAIL_FOLDERS' => SugarThemeRegistry::current()->getImage('icon_email_folder', 'align=absmiddle border=0', null, null, '.gif', '') . 'Folders',
+    'LBL_EMAIL_FOLDERS_SHORT' => SugarThemeRegistry::current()->getImage('icon_email_folder', 'align=absmiddle border=0', null, null, '.gif', ''),
     'LBL_EMAIL_FOLDERS_ADD' => 'Add',
     'LBL_EMAIL_FOLDERS_ADD_DIALOG_TITLE' => 'Add New Folder',
     'LBL_EMAIL_FOLDERS_RENAME_DIALOG_TITLE' => 'Rename Folder',
@@ -1401,22 +1381,8 @@ $app_strings = array(
     'LBL_EMAIL_SAVE_DRAFT' => 'Save Draft',
     'LBL_EMAIL_DRAFT_SAVED' => 'Draft has been saved',
 
-    'LBL_EMAIL_SEARCH' => SugarThemeRegistry::current()->getImage(
-        'Search',
-        'align=absmiddle border=0',
-        null,
-        null,
-        '.gif',
-        ''
-    ),
-    'LBL_EMAIL_SEARCH_SHORT' => SugarThemeRegistry::current()->getImage(
-        'Search',
-        'align=absmiddle border=0',
-        null,
-        null,
-        '.gif',
-        ''
-    ),
+    'LBL_EMAIL_SEARCH' => SugarThemeRegistry::current()->getImage('Search', 'align=absmiddle border=0', null, null,    '.gif', ''),
+    'LBL_EMAIL_SEARCH_SHORT' => SugarThemeRegistry::current()->getImage('Search', 'align=absmiddle border=0', null,        null, '.gif', ''),
     'LBL_EMAIL_SEARCH_DATE_FROM' => 'Date From',
     'LBL_EMAIL_SEARCH_DATE_UNTIL' => 'Date Until',
     'LBL_EMAIL_SEARCH_NO_RESULTS' => 'No results match your search criteria.',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix #336 Some strings in the language core files do not work with Crowdin and do not allow the files to be parsed /translated/downloaded.
Crowdin should load files directly from GITHUB SuiteCRM core project

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Crowdin project has been working with a side load files by me. I can't maintain it no longer so the files must be 100% the same as the SuiteCRM Git source.
Those strings that must be changed in the core files so Crowdin won't break.
https://crowdin.com/translate/suitecrmtranslations/

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->