### PR TITLE
Fixing to display the labels on each column to line items

### DIFF
--- a/public/legacy/modules/AOS_Products_Quotes/Line_Items.php
+++ b/public/legacy/modules/AOS_Products_Quotes/Line_Items.php
@@ -40,6 +40,7 @@ function display_lines($focus, $field, $value, $view)
         $html .= 'var module_sugar_grp1 = "'.$focus->module_dir.'";';
         $html .= 'var enable_groups = '.$enable_groups.';';
         $html .= 'var total_tax = '.$total_tax.';';
+        $html .= "SUGAR.language.setLanguage(module_sugar_grp1, ".json_encode($mod_strings).");";
         $html .= '</script>';
 
         $html .= "<table border='0' cellspacing='4' id='lineItems'></table>";


### PR DESCRIPTION
Fixing to loading and display labels in each column to line items as expected.

## Description
When I been use the last version of CRM in the module Quotes I try made a new quote at the moment click add new line the title in each column showed 'undefined' the same case to the fields totals

I opened the code inspector in my web explorer so to inspected why displayed the 'undefined' when I located the object where I supposed the labels must retrieve after a couple test I been never get any expected result.

I made a couple test to load the labels to this part and I overwrite this code to folder 'custom' and works fine to me.

## Motivation and Context
I needed to customize module how part a solution to customer.
With this fix loading fine the labels to each column line items and displayed correctly now

## How To Test This
Well I been testing the changes when I make a new Quote and I clicking to add new line item and now view the label correctly to each column and total fields

## Types of changes
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
