### PR TITLE
Fix #10205. Compatibility hotfix for PHP 8 in ActivitiesRelationship.php

### DIFF
--- a/public/legacy/modules/ModuleBuilder/parsers/relationships/ActivitiesRelationship.php
+++ b/public/legacy/modules/ModuleBuilder/parsers/relationships/ActivitiesRelationship.php
@@ -96,7 +96,7 @@ class ActivitiesRelationship extends OneToManyRelationship
      * Define the labels to be added to the module for the new relationships
      * @return array    An array of system value => display value
      */
-    public function buildLabels()
+    public function buildLabels($update = false)
     {
         $labelDefinitions = array( ) ;
         if (!$this->relationship_only) {
@@ -155,7 +155,7 @@ class ActivitiesRelationship extends OneToManyRelationship
         return $vardefs ;
     }
 
-    protected function getLinkFieldDefinition($sourceModule, $relationshipName)
+    protected function getLinkFieldDefinition($sourceModule, $relationshipName, $right_side = false, $vname = "", $id_name = false)
     {
         $vardef = array( ) ;
         $vardef [ 'name' ] = $relationshipName;


### PR DESCRIPTION
Solution for the issue #10205

Changed ActivitiesRelationship#buildLabels and ActivitiesRelationship#getLinkFieldDefinition parameter to match parent class parameters to avoid exceptions when using PHP8

## Description
The child class methods should contain the same parameters as the parent class. Without does changes the CRM throws an error when you try to deploy a package with a module related to Activities.

## How To Test This
1. Create a new package in the module builder
2. Add a new custom module in the package
3. Add a relationship between the new custom module and Activities (One-To-Many)
4. Deploy the package.

The package should be deployed correctly without any failure.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.