### PR TITLE
Include all not displayed fields in Record

### DIFF
--- a/core/app/common/src/lib/metadata/metadata.model.ts
+++ b/core/app/common/src/lib/metadata/metadata.model.ts
@@ -30,6 +30,7 @@ import {BehaviorSubject, Observable} from 'rxjs';
 
 export interface ViewFieldDefinition {
     name?: string;
+    vardefBased?: boolean;
     label?: string;
     labelKey?: string;
     dynamicLabelKey?: string;
@@ -63,7 +64,7 @@ export interface PanelCell extends ViewFieldDefinition {
 }
 
 export interface ViewFieldDefinitionMap {
-    [key: string]: ViewFieldDefinition
+    [key: string]: ViewFieldDefinition;
 }
 
 export interface TabDefinitions {
@@ -86,12 +87,12 @@ export interface LogicDefinition {
     modes: Array<string>;
     params: {
         activeOnFields?: {
-            [key:string]: LogicRuleValues[];
-        }
+            [key: string]: LogicRuleValues[];
+        };
         displayState?: boolean;
         fieldDependencies: Array<string>;
         asyncProcessHandler?: string;
-    }
+    };
 }
 
 export interface LogicRuleValues{

--- a/core/app/core/src/lib/services/record/field/field.manager.ts
+++ b/core/app/core/src/lib/services/record/field/field.manager.ts
@@ -148,17 +148,18 @@ export class FieldManager {
 
     /**
      * Build line item and add to record
-     * @param {object} itemDefinition
-     * @param {object }item
-     * @param {object} parentRecord
-     * @param {object} parentField
+     *
+     * @param {FieldDefinition} itemDefinition Item Definition
+     * @param {Record} parentRecord Parent Record
+     * @param {Field} parentField Parent Field
+     * @param {Record | null} item Item
      */
     public addLineItem(
         itemDefinition: FieldDefinition,
         parentRecord: Record,
         parentField: Field,
         item: Record = null
-    ) {
+    ): void {
         if (!item) {
             item = {
                 id: '',
@@ -183,10 +184,11 @@ export class FieldManager {
 
     /**
      * Remove line item
-     * @param {object} parentField
-     * @param index
+     *
+     * @param {Field} parentField Parent Field
+     * @param {number} index Index
      */
-    public removeLineItem(parentField: Field, index: number) {
+    public removeLineItem(parentField: Field, index: number): void {
         const item = parentField.items[index];
 
         if (!item) {
@@ -204,13 +206,13 @@ export class FieldManager {
 
         parentField.itemFormArray.clear();
 
-        parentField.items.forEach(item => {
-            const deleted = item && item.attributes && item.attributes.deleted;
-            if (!item || deleted) {
+        parentField.items.forEach(parentItem => {
+            const deleted = parentItem && parentItem.attributes && parentItem.attributes.deleted;
+            if (!parentItem || deleted) {
                 return;
             }
 
-            parentField.itemFormArray.push(item.formGroup);
+            parentField.itemFormArray.push(parentItem.formGroup);
         });
 
         parentField.itemFormArray.updateValueAndValidity();
@@ -243,6 +245,45 @@ export class FieldManager {
         if (record.formGroup && field.formControl) {
             record.formGroup.addControl(name, field.formControl);
         }
+    }
+
+
+    /**
+     * Build and add vardef only field to record
+     *
+     * @param {object} record Record
+     * @param {object} viewField ViewFieldDefinition
+     * @param {object} language LanguageStore
+     * @returns {object}Field
+     */
+    public addVardefOnlyField(record: Record, viewField: ViewFieldDefinition, language: LanguageStore = null): Field {
+
+        const field = this.fieldBuilder.buildField(record, viewField, language);
+
+        this.addVardefOnlyFieldToRecord(record, viewField.name, field);
+
+        return field;
+    }
+
+
+    /**
+     * Add field to record
+     *
+     * @param {object} record Record
+     * @param {string} name string
+     * @param {object} field Field
+     */
+    public addVardefOnlyFieldToRecord(record: Record, name: string, field: Field): void {
+
+        if (!record || !name || !field) {
+            return;
+        }
+
+        if (!record.fields) {
+            record.fields = {};
+        }
+
+        record.fields[name] = field;
     }
 
 

--- a/core/app/core/src/lib/services/record/record.manager.ts
+++ b/core/app/core/src/lib/services/record/record.manager.ts
@@ -81,6 +81,18 @@ export class RecordManager {
             if (!viewField || !viewField.name) {
                 return;
             }
+
+            if(record.fields[viewField.name]) {
+                return;
+            }
+
+            const isVardefBased = viewField?.vardefBased ?? false;
+
+            if (isVardefBased) {
+                this.fieldManager.addVardefOnlyField(record, viewField, this.language);
+                return;
+            }
+
             this.fieldManager.addField(record, viewField, this.language);
         });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Sometimes is needed to have access to the current state and modify some fields that are not part of the view.

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
  - ESLint fixes on modified files.
  - `core/app/common/src/lib/metadata/metadata.model.ts:33`: add `vardefBased?: boolean;` to `ViewFieldDefinition` interface.
  - `core/app/core/src/lib/views/record/store/record-view/record-view.store.ts:643~679`: modify `getViewFieldsObservable` function of `RecordViewStore` class to include vardef based view fields into ViewFieldDefinition.
  - `core/app/core/src/lib/services/record/field/field.manager.ts:251~289`: add `addVardefOnlyField` function to `FieldManager` class to being able to include vardef fields into record.
  - `core/app/core/src/lib/services/record/record.manager.ts:84`: when the viewFields are incorporating into the record, use `addVardefOnlyField` function instead of `addField`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sometimes you need to modify non-visible fields by certain logic, and, by this time, if you do not include a field in viewdef (hidden mode if you do not want to show it) you can't do that.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
  - Include the code provided later into `core/app/core/src/lib/views/record/store/record-view/record-view.store.ts` constructor .
  - Rebuild frontend.
  - Open browser with devtool console opened.
  - Open any record.
  - You will see in console a table with a list of fields that comes from view or vardef. Without the new code, you only will see records that comes from view.

### Code to include:
```ts
        this.getViewFieldsObservable().
          pipe(take(1)).
          subscribe((viewFieldDefinition) => {
              console.log('RecordViewStore.constructor: this.getViewFieldsObservable():');
              console.table(
                Object.values(viewFieldDefinition).map(viewField => ({
                    source: (viewField.vardefBased ?? false) ? 'Vardef' : 'View',
                    name: viewField.name,
                })),
              );
          });
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->