### PR TITLE
Fix #401 ACL Check recordModule instead of Module, if available

### DIFF
--- a/core/backend/Process/Service/RecordActions/EditAction.php
+++ b/core/backend/Process/Service/RecordActions/EditAction.php
@@ -73,7 +73,7 @@ class EditAction implements ProcessHandlerInterface
     public function getRequiredACLs(Process $process): array
     {
         $options = $process->getOptions();
-        $module = $options['module'] ?? '';
+        $module = $options['payload']['recordModule'] ?? $options['module'] ?? '';
 
         $baseModule = $options['payload']['baseModule'] ?? '';
         $baseRecord = $options['payload']['baseRecordId'] ?? '';


### PR DESCRIPTION

## Description
See the Issue #401 for details and steps to reproduce **one case** of this bug; but there are others.

**ATTENTION**: I know this fixes the specific use case that generated the Issue, but it's hard to think of all the different situations that this change might impact. So please @clemente-raposo have a look and see if this is the proper way to fix it, you have a better notion than me of when the recordModule parameter is present in the request, and when it is not.

## Motivation and Context
See issue.
## How To Test This
See issue. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
