### PR TITLE
Fix #274 - Views Incorrectly Encode UTF Characters as HTML Entities

### DIFF
--- a/public/legacy/include/utils/db_utils.php
+++ b/public/legacy/include/utils/db_utils.php
@@ -72,6 +72,7 @@ $toHTML = array(
     '>' => '&gt;',
     "'" => '&#039;',
 );
+$GLOBALS['toHTML'] = $toHTML;
 $GLOBALS['toHTML_keys'] = array_keys($toHTML);
 $GLOBALS['toHTML_values'] = array_values($toHTML);
 $GLOBALS['toHTML_keys_set'] = implode("", $GLOBALS['toHTML_keys']);


### PR DESCRIPTION
## Description
See the issue #274 for more details about the issue.

I identified that when the incorrectly encoded characters showed up the [to_html](https://github.com/salesagility/SuiteCRM-Core/blob/117dd8172793a239f71c91222606bf00677eeb33/public/legacy/include/utils/db_utils.php#L90) function didn't have the `$toHTML` global array so instead used the [htmlentities](https://www.php.net/manual/en/function.htmlentities.php) function causing the html encodings.

https://github.com/salesagility/SuiteCRM-Core/blob/117dd8172793a239f71c91222606bf00677eeb33/public/legacy/include/utils/db_utils.php#L99-L102

With the small change of defining the variable in the `$GLOBALS` array, the function will use that and encode it correctly.

There might be more related to encoding issues but this fixes my issues and what it looks like the issue is having. 

## Motivation and Context

## How To Test This
1. Change the name of something that is referenced.
 a. For example, change the company name that is referenced in a Call. (Like adding åäö or other letters)
2. Got the the list of that data and you should see the HTML encoded letters

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
