### PR TITLE
Fix #74 Can't login when SuiteCRM 8 is behind a LoadBalancer

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -20,6 +20,12 @@ DirectoryIndex index.php
 <IfModule mod_rewrite.c>
     RewriteEngine On
 
+    # Fix #74 Redirect http to https (except when request comes from localhost).
+    # This is the security requirement for login.
+    RewriteCond %{REMOTE_ADDR} !^127\.0\.0\.1
+    RewriteCond %{HTTPS} !=on
+    RewriteRule ^/?(.*) https://%{HTTP_HOST}/$1 [R=301,L]
+
     RewriteRule ^index.php.*$ - [L,NC]
 
     # Determine the RewriteBase automatically and set it as environment variable.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
When using the v8 application behind a load balancer, the requests come in as `http`, even when the application is installed with `https` enabled.  This causes login failure.
This change causes the `http` request from the proxy to be rewritten as `https` so that the application's security requirement for login is satisfied.  The application allows login only from `https`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Login should be working now, when running v8 behind a `http` proxy or load balancer (e.g. Kubernetes, Helm Charts).
Bitnami should undo its deprecation of SuiteCRM v8 from the list of supported Helm Charts applications.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Install v8 application behind a http proxy or load balancer, without the changes.
Try to login.  It should fail with a variety of error messages.
Apply the changes.  Login should work fine.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->