### PR TITLE
Fix salesagility#381 - Dynamic dropdown

### DIFF
--- a/core/app/core/src/lib/fields/base/base-enum.component.ts
+++ b/core/app/core/src/lib/fields/base/base-enum.component.ts
@@ -323,12 +323,14 @@ export class BaseEnumComponent extends BaseFieldComponent implements OnInit, OnD
                     values = [values];
                 }
 
-                // Reset selected values on Form Control
-                this.field.value = '';
-                this.field.formControl.setValue('');
-
                 // Rebuild available enum options
                 this.options = this.filterMatchingOptions(values);
+
+                // reset value on dynamic enum value if parent enum is empty or does not allow the selected value
+                if (!(this.options.some(option => option.value === this.field.value)) || values == ''){
+                    this.field.value = '';
+                    this.field.formControl.setValue('');
+                }
 
                 this.initValue();
             }));


### PR DESCRIPTION
# Fixing the value emptying of a dynamic dropdown

## Description
Adding a condition for the emptying of the value in a dynamic enum.

This bug is present in 8.5.0 and is the standard behavior: when you save a record containing a dynamic enum, then the value in the dynamic enum is not sent to the server. This is because it is constantly reset by the following code in core/app/core/src/lib/fields/base/base-enum.component.ts

```
// Reset selected values on Form Control
this.field.value = '';
this.field.formControl.setValue('');
```

I added the following condition

```
// reset value on dynamic enum value if parent enum is empty or does not allow the selected value
if (!(this.options.some(option => option.value === this.field.value)) || values == ''){
this.field.value = '';
this.field.formControl.setValue('');
}
```

https://github.com/salesagility/SuiteCRM-Core/issues/381

As per this issue above, a fix for this bug is needed because the value of the dynamic enum is never saved. The fix I propose brings the expected behaviour: the value is only reset when changing the parent value, or if there is a mismatch between the list of possible values of the parent values and the current value. 

To test the change, set a value in your dynamic dropdown and look at the value in your database after saving. You can also echo the request from the kernel to see that the proper value is sent to the server, it is how i found out that it was caused by angular and not the server: the value was empty inside the request.
You can also change the value in the parent enum to make sure that the value of the child enum is reset as intended

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.