### PR TITLE
Fix #491 - Diagnostic Tool broken in latest version

### DIFF
--- a/public/legacy/modules/Administration/DiagnosticRun.php
+++ b/public/legacy/modules/Administration/DiagnosticRun.php
@@ -757,8 +757,8 @@ function finishDiag()
     chdir(RETURN_FROM_DIAG_DIR);
 
     deleteDir($cacheDir);
-    
-    
+
+
     print "<a href=\"index.php?module=Administration&action=DiagnosticDownload&guid=$sod_guid&time=$curdatetime&to_pdf=1\">".$mod_strings['LBL_DIAGNOSTIC_DOWNLOADLINK']."</a><BR>";
 
     deleteDir($cacheDir);
@@ -768,18 +768,18 @@ function finishDiag()
 }
 
 //BEGIN check for what we are executing
-$doconfigphp = ((empty($_POST['configphp']) || $_POST['configphp'] == 'off') ? false : true);
-$docustom_dir = ((empty($_POST['custom_dir']) || $_POST['custom_dir'] == 'off') ? false : true);
-$dophpinfo = ((empty($_POST['phpinfo']) || $_POST['phpinfo'] == 'off') ? false : true);
-$domysql_dumps = ((empty($_POST['mysql_dumps']) || $_POST['mysql_dumps'] == 'off') ? false : true);
-$domysql_schema = ((empty($_POST['mysql_schema']) || $_POST['mysql_schema'] == 'off') ? false : true);
-$domysql_info = ((empty($_POST['mysql_info']) || $_POST['mysql_info'] == 'off') ? false : true);
-$domd5 = ((empty($_POST['md5']) || $_POST['md5'] == 'off') ? false : true);
-$domd5filesmd5 = ((empty($_POST['md5filesmd5']) || $_POST['md5filesmd5'] == 'off') ? false : true);
-$domd5calculated = ((empty($_POST['md5calculated']) || $_POST['md5calculated'] == 'off') ? false : true);
-$dobeanlistbeanfiles = ((empty($_POST['beanlistbeanfiles']) || $_POST['beanlistbeanfiles'] == 'off') ? false : true);
-$dosugarlog = ((empty($_POST['sugarlog']) || $_POST['sugarlog'] == 'off') ? false : true);
-$dovardefs = ((empty($_POST['vardefs']) || $_POST['vardefs'] == 'off') ? false : true);
+$doconfigphp = ((empty($_GET['configphp']) || $_GET['configphp'] == 'off') ? false : true);
+$docustom_dir = ((empty($_GET['custom_dir']) || $_GET['custom_dir'] == 'off') ? false : true);
+$dophpinfo = ((empty($_GET['phpinfo']) || $_GET['phpinfo'] == 'off') ? false : true);
+$domysql_dumps = ((empty($_GET['mysql_dumps']) || $_GET['mysql_dumps'] == 'off') ? false : true);
+$domysql_schema = ((empty($_GET['mysql_schema']) || $_GET['mysql_schema'] == 'off') ? false : true);
+$domysql_info = ((empty($_GET['mysql_info']) || $_GET['mysql_info'] == 'off') ? false : true);
+$domd5 = ((empty($_GET['md5']) || $_GET['md5'] == 'off') ? false : true);
+$domd5filesmd5 = ((empty($_GET['md5filesmd5']) || $_GET['md5filesmd5'] == 'off') ? false : true);
+$domd5calculated = ((empty($_GET['md5calculated']) || $_GET['md5calculated'] == 'off') ? false : true);
+$dobeanlistbeanfiles = ((empty($_GET['beanlistbeanfiles']) || $_GET['beanlistbeanfiles'] == 'off') ? false : true);
+$dosugarlog = ((empty($_GET['sugarlog']) || $_GET['sugarlog'] == 'off') ? false : true);
+$dovardefs = ((empty($_GET['vardefs']) || $_GET['vardefs'] == 'off') ? false : true);
 //END check for what we are executing
 
 


### PR DESCRIPTION
## Description
The Diagnostic Tool currently doesn't accept any information from the checkboxes since a change to using GET request instead of POST request in the form.

Fixes issue https://github.com/salesagility/SuiteCRM-Core/issues/491

## Motivation and Context
Unable to retrieve diagnostic information from the tool.

## How To Test This
1. Go to the Diagnostic Tool
2. Check some options for Diagnosing
3. Click on Execute Diagnostic
4. The Diagnostic Tool will be stuck on 0% and not complete.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->