### PR TITLE
Fix #493 - Improve Cache Clear Speed

### DIFF
--- a/core/backend/Install/Service/Cache/CacheBridge.php
+++ b/core/backend/Install/Service/Cache/CacheBridge.php
@@ -69,9 +69,8 @@ class CacheBridge
         $feedback->setSuccess(true)->setMessages(['Successfully cleared cache']);
 
         try {
-            $fs = new Filesystem();
-            $fs->remove($this->cacheDir);
 
+            $this->clearCacheDir();
             $this->clearPhpCache();
 
         } catch (Exception $e) {
@@ -94,6 +93,24 @@ class CacheBridge
 
         if (function_exists('apcu_clear_cache')) {
             apcu_clear_cache();
+        }
+    }
+
+    /**
+     * Rename and delete cache subdirectory
+     * @param $fs
+     * @param $tempId
+     * @return void
+     */
+    protected function clearCacheDir() : void
+    {
+        $fs = new Filesystem();
+        $tempId = uniqid();
+
+        if($fs->exists($this->cacheDir)){
+            $fs->rename($this->cacheDir, $this->cacheDir . '_' . $tempId . '_deprecated/');
+            $fs->mkdir($this->cacheDir);
+            $fs->remove($this->cacheDir . '_' . $tempId . '_deprecated/');
         }
     }
 

--- a/public/legacy/include/portability/classicview_routing_exclusions.php
+++ b/public/legacy/include/portability/classicview_routing_exclusions.php
@@ -29,7 +29,13 @@ $classicview_routing_exclusions = [
     'any' => [
         'ShowDuplicates'
     ],
+    'administration' => [
+        'upgrade',
+        'repair'
+    ],
     'Administration' => [
+        'upgrade',
+        'repair',
         'UpgradeWizard_prepare',
         'UpgradeWizard_commit'
     ],


### PR DESCRIPTION
## Description
Clearing the cache from file systems can be slow depending on the environment. Quick Repair and Rebuild should also avoid deleting the root cache folder incase the folder is mounted.

## Motivation and Context
Improves the process by renaming the cache folder before deleting it, since rename is much faster than delete.

Quick Repair and Rebuild should only run once instead of twice due to classic view routing issues. Exception added for repair and upgrade.

Quick Repair and Rebuild should target the subdirectories within the cache folder rather than deleting the root cache folder.

## How To Test This
1. Run Quick Repair and Rebuild
2. Check the Cache folder during each step cache renaming/deleting step if debugging is enabled
3. Check that cache key is added to the cache_rebuild database table
4. Navigate the CRM, check the cache key is deleted from the cache_rebuild database table
5. Check for errors in the console while navigating the CRM

For the CacheBridge

1. Install SuiteCRM v8.5
2. Add the code from CacheBridge.php to the pre and post(upgrade pack) files.
3. Run the upgrade checking for errors
4. Check the CRM post upgrade for any errors in the console


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->