### PR TITLE
#529 Fix survey module textarea overflow

### DIFF
--- a/public/legacy/themes/suite8/css/suitep-base/editview.scss
+++ b/public/legacy/themes/suite8/css/suitep-base/editview.scss
@@ -3657,7 +3657,7 @@ select#sales_stage_advanced {
   }
 
   .col-sm-12 .col-sm-8.edit-view-field textarea#description {
-    width: 100%;
+    width: 90%;
   }
 
   .col-sm-12 .col-sm-8.edit-view-field textarea {
@@ -4280,6 +4280,7 @@ h3 span {
 .fix-inlineEdit-textarea {
   word-wrap: break-word;
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .inlineEditIcon {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When creating/editing a survey, the description goes off page and is not contained within the Description box

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->