### PR TITLE
replace `require` with `require_once` in entryPoint.php

### DIFF
--- a/public/legacy/include/entryPoint.php
+++ b/public/legacy/include/entryPoint.php
@@ -131,10 +131,10 @@ require_once 'include/utils/autoloader.php';
 spl_autoload_register(array('SugarAutoLoader', 'autoload'));
 require_once 'data/SugarBean.php';
 require_once 'include/utils/mvc_utils.php';
-require 'include/SugarObjects/LanguageManager.php';
-require 'include/SugarObjects/VardefManager.php';
+require_once 'include/SugarObjects/LanguageManager.php';
+require_once 'include/SugarObjects/VardefManager.php';
 
-require 'modules/DynamicFields/templates/Fields/TemplateText.php';
+require_once 'modules/DynamicFields/templates/Fields/TemplateText.php';
 
 require_once 'include/utils/file_utils.php';
 require_once 'include/SugarEmailAddress/SugarEmailAddress.php';
@@ -150,7 +150,7 @@ require_once 'include/utils/LogicHook.php';
 require_once 'include/SugarTheme/SugarTheme.php';
 require_once 'include/MVC/SugarModule.php';
 require_once 'include/SugarCache/SugarCache.php';
-require 'modules/Currencies/Currency.php';
+require_once 'modules/Currencies/Currency.php';
 require_once 'include/MVC/SugarApplication.php';
 
 require_once 'include/upload_file.php';


### PR DESCRIPTION
## Description
I am not a "PHP Guy", so this could be wrong. However, it fixes error messages such as:

>PHP Fatal error:  Cannot declare class TemplateText, because the name is already in use

Same with `LanguageManager.php` and `VardefManager.php`, and likely but not confirmed, `TemplateText.php`.

## Motivation and Context
I noticed the error while authenticating via the API, when the server returned 500.

## How To Test This
Execute the below command and verify that the above error message does not appear in the log.

```shell
curl --location --request GET 'localhost/service/v4_1/rest.php' \
--header 'Content-Type: application/x-www-form-urlencoded' \
--data-urlencode 'method=login' \
--data-urlencode 'input_type=JSON' \
--data-urlencode 'response_type=JSON' \
--data-urlencode 'rest_data={"user_auth":{"user_name":"admin","password":"password"},"application_name":"test"}'
```

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ _ ] New feature (non-breaking change which adds functionality)
- [ _ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [ x ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ _ ] My change requires a change to the documentation.
- [ x ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.