### PR TITLE
Patch 2

### DIFF
--- a/public/legacy/include/UploadStream.php
+++ b/public/legacy/include/UploadStream.php
@@ -52,6 +52,7 @@ require_once('include/externalAPI/ExternalAPIFactory.php');
 class UploadStream
 {
     public const STREAM_NAME = "upload";
+    private static $is_registered = false;
     protected static $upload_dir;
 
     /**
@@ -148,7 +149,10 @@ class UploadStream
      */
     public static function register()
     {
-        stream_wrapper_register(self::STREAM_NAME, self::class);
+        if (!self::$is_registered) {
+            stream_wrapper_register(self::STREAM_NAME, self::class);
+            self::$is_registered = true;
+        }
     }
 
     /**

--- a/public/legacy/include/UploadStream.php
+++ b/public/legacy/include/UploadStream.php
@@ -52,7 +52,7 @@ require_once('include/externalAPI/ExternalAPIFactory.php');
 class UploadStream
 {
     public const STREAM_NAME = "upload";
-    private static $is_registered = false;
+    private static $isRegistered = false;
     protected static $upload_dir;
 
     /**
@@ -149,9 +149,9 @@ class UploadStream
      */
     public static function register()
     {
-        if (!self::$is_registered) {
+        if (!self::isRegistered) {
             stream_wrapper_register(self::STREAM_NAME, self::class);
-            self::$is_registered = true;
+            self::isRegistered = true;
         }
     }
 


### PR DESCRIPTION
## Description
Fixes this warning in the log:
> PHP Warning:  stream_wrapper_register(): Protocol upload:// is already defined. in /bitnami/suitecrm/public/legacy/include/UploadStream.php on line 151

## Motivation and Context
For cleaner log output.

## How To Test This
Run SuiteCRM and try to login via the API. Note the warning above appears in the Apache log.

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [ x ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ x ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
