### PR TITLE
decode HTML entities in REST/JSON service

### DIFF
--- a/public/legacy/service/core/REST/SugarRestJSON.php
+++ b/public/legacy/service/core/REST/SugarRestJSON.php
@@ -84,7 +84,7 @@ class SugarRestJSON extends SugarRest{
 	 */
 	public function serve(){
 		$GLOBALS['log']->info('Begin: SugarRestJSON->serve');
-		$json_data = !empty($_REQUEST['rest_data'])? $GLOBALS['RAW_REQUEST']['rest_data']: '';
+		$json_data = html_entity_decode(!empty($_REQUEST['rest_data'])? $GLOBALS['RAW_REQUEST']['rest_data']: '');
 		if(empty($_REQUEST['method']) || !method_exists($this->implementation, $_REQUEST['method'])){
 			$er = new SoapError();
 			$er->set_error('invalid_call');


### PR DESCRIPTION
## Description
I worked on this for many hours, trying to figure out why my API calls were never working. After digging through and adding logging, I found that the `rest_data` parameter was not being properly HTML-entity-decoded.

## Motivation and Context
8.7.0 REST API simply does not work.

## How To Test This

This will fail using the current 8.7.0 API:

```
curl -X POST http://localhost:3001/service/v4_1/rest.php -H 'Content-Type: application/x-www-form-urlencoded' -d 'input_type=JSON' -d 'response_type=JSON' -d 'method=login' -d 'rest_data={"user_auth":{"user_name":"admin","password":"dd995564b1fa70241364c5926aa27997"},"application":"test"}'
```

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ * ] Breaking change (fix or feature that would cause existing functionality to change)

* I don't _think_ this is a breaking change. As far as I can tell, there is no way to use the API as-is. But I ... must be wrong, right?

### Final checklist
- [ x ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ x ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
