### PR TITLE
Fix #560 - removed equality check between fieldKey and name in return condition of addFieldDepedency() to allow addition of the field itself as a dependency

### DIFF
--- a/core/app/core/src/lib/fields/base/base-field.component.ts
+++ b/core/app/core/src/lib/fields/base/base-field.component.ts
@@ -207,7 +207,7 @@ export class BaseFieldComponent implements FieldComponentInterface, OnInit, OnDe
     protected addFieldDependency(fieldKey: string, dependentFields: ObjectMap, dependentAttributes: AttributeDependency[]): void {
         const field = this.record.fields[fieldKey];
         const name = this.field.name || this.field.definition.name || '';
-        if (fieldKey === name || !field) {
+        if (!field) {
             return;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

This PR will close #560 

Enable an user to add a field as its own dependency under displayLogic, so that a field display can change based on a value of the field itself.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In my project using CRM, I have a field which requires to adjust its display type based on a value of the field itself.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
For any field, configure the field itself as a dependency such as follows as an example:

```
$dictionary['Lead']['fields']['status']['displayLogic'] = [
    'readonly_when_converted' => [
        'key' => 'displayType',
        'modes' => ['edit'],
        'params' => [
            'fieldDependencies' => [
                'status'
            ],
            'targetDisplayType' => 'readonly',
            'activeOnFields' =>  [
                'status' => [ 'Finished' ]
            ]
        ]
    ]
];
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ x ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ x ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->