### PR TITLE
Fix #567 - Using iconv_mime_encode to fix email sending

### DIFF
--- a/public/legacy/include/Localization/Localization.php
+++ b/public/legacy/include/Localization/Localization.php
@@ -451,11 +451,15 @@ class Localization
      */
     public function translateCharsetMIME($string, $fromCharset, $toCharset = 'UTF-8', $encoding = "Q")
     {
-        $previousEncoding = mb_internal_encoding();
-        mb_internal_encoding($fromCharset);
-        $result = mb_encode_mimeheader($string, $toCharset, $encoding);
-        mb_internal_encoding($previousEncoding);
-        return $result;
+        $preferences = array(
+            'input-charset' => $fromCharset,
+            'output-charset' => $toCharset,
+            'line-length' => 76,
+            'scheme' => $encoding,
+            'line-break-chars' => "\n"
+        );
+        $result = iconv_mime_encode('', $string, $preferences);
+        return substr($result, 2);
     }
 
     public function normalizeCharset($charset)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This update addresses a critical bug in the Localization.php file within the translateCharsetMIME function, which was causing an error during email sending. The issue was linked to the use of mb_encode_mimeheader, which triggered a warning due to updates in the polyfill-mbstring dependency.

## Motivation and Context
There is a failing code in the legacy Localization.php in translateCharsetMIME function causing error on email sending.

## How To Test This
1. Set up an new suitecrm environment (tested on 8.7 and php 8.2)
2. Login and go to admin page
3. Configure email and try to send a test email

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.