### PR TITLE
Added support for relate fields in update value backend actions

### DIFF
--- a/core/app/core/src/lib/fields/field-logic/update-value-backend/update-value-backend.action.ts
+++ b/core/app/core/src/lib/fields/field-logic/update-value-backend/update-value-backend.action.ts
@@ -159,11 +159,27 @@ export class UpdateValueBackendAction extends FieldLogicActionHandler {
      * @param {string} value
      * @param {object} record
      */
-    protected updateValue(field: Field, value: string, record: Record): void {
-        field.value = value.toString();
-        field.formControl.setValue(value);
+    protected updateValue(field: Field, value: string, record: Record): void {        
+        switch (field.type) {
+            case "relate": 
+                const relateValue = JSON.parse(value);
+
+                // Field that displays the related record 
+                field.value = relateValue.id.toString();
+                field.valueObject = {id: relateValue.id, name: relateValue.name};
+                field.formControl.setValue({...field.valueObject});
+
+                // Field that stores the related record's ID
+                const relateFieldDB = record.fields[field.definition.id_name];
+                relateFieldDB.value = field.value;
+                relateFieldDB.formControl.setValue(field.value);
+
+            default: 
+                field.value = value.toString();
+                field.formControl.setValue(value);
+        }
+
         // re-validate the parent form-control after value update
         record.formGroup.updateValueAndValidity({onlySelf: true, emitEvent: true});
     }
-
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
This PR introduces support for updating values through backend actions for relate fields in SuiteCRM 8. Previously, the system did not support updating these fields, limiting the functionality of working with relationships in modules. With this enhancement, relate fields can now be managed more comprehensively via the backend.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The official SuiteCRM documentation previously mentioned that backend value updates were not supported for relate fields. This change aims to extend the current capabilities and ensure that relate fields are also manageable in the backend. This is particularly beneficial when creating custom logic to update the relate field.
### Specific Implementation for Relate Fields
To address the limitation of updating relate fields, the backend requires a specific response structure to ensure proper updates. The `run` method in the backend handler must provide the response data in the following format to update relate fields:

```php
public function run(Process $process)
{
    global $db, $app_list_strings;
    $options = $process->getOptions();
    $record = $options['record'];
    $attributes = $record['attributes'];

    $responseData = [
        'value' => json_encode([
            'id' => '72773dab-a9ee-e545-702a-674652570e09',  // The related record ID
            'name' => 'Test',  // The related record name
        ]),
    ];

    $process->setStatus('success');
    $process->setMessages([]);
    $process->setData($responseData);
}
```

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. **Create or Use Existing Module**: Create a module with relate fields using the Module Builder.
2. **Apply Backend Update Logic**: Use the custom backend handler to update a relate field through the backend.
3. **Check Updates**: Ensure that the relate field updates correctly without any issues. Validate the change by reviewing the database and UI.

### Example Test:
- Create a new Contact record.
- Relate the Contact to an Account.
- Update a value in the relate Account field via backend logic using the appropriate structure.
- Verify that the change is successfully reflected in both the database and the SuiteCRM UI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [x ] My change requires a change to the documentation.
- [x ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->