### PR TITLE
Fix #592 - Add null check to DetailView

### DIFF
--- a/public/legacy/include/SugarFields/Fields/Parent/DetailView.tpl
+++ b/public/legacy/include/SugarFields/Fields/Parent/DetailView.tpl
@@ -39,6 +39,7 @@
  */
 
 *}
+{if !empty({{sugarvar objectName='fields' memberName='vardef.type_name' key='value'}})}
 {capture assign='url'}index.php?module={{sugarvar objectName='fields' memberName='vardef.type_name' key='value'}}&action=DetailView&record={{sugarvar key='value' memberName='vardef.id_name'}}{/capture}
 {{if !$nolink}}
 <input type="hidden" class="sugar_field" id="{{sugarvar key='name'}}" value="{{sugarvar key='value'}}">
@@ -50,3 +51,4 @@
 {{sugarvar_connector view='DetailView'}}
 {/if}
 {{/if}}
+{/if}


### PR DESCRIPTION
Add a null check so it doesn't blindly capture data that may not exist. This was causing an issue where the template wouldn't render if the "parent_type" was null in the database.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We had an issue where emails just were not loading in `DetailView`. It took forever to figure out why this was happening, and then even longer to figure out what was responsible for it. If an email has nothing set for `related to`, the associated field of `parent_id` is `NULL` in the database, which causes the `capture` to fail and not render the template on the page.
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
[Bug Issue](https://github.com/salesagility/SuiteCRM-Core/issues/592)
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Emails not containing parent data will simply not render in the template because of an error within the `capture`. Adding a null check resolves this issue and will display the detailed view of an email.

## How To Test This
<!--- Please describe in detail how to test your changes. -->
1. Have an email in the database with `parent_type` set to `null`, or an empty string.
2. Attempt to view that email record `http://localhost:8080/#/emails/record/<id>`
3. View a detailed view of that email

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->