### PR TITLE
Fix #613 - Fixed Error Occurring If First Report Field Is a Custom Field

### DIFF
--- a/public/legacy/modules/AOR_Reports/AOR_Report.php
+++ b/public/legacy/modules/AOR_Reports/AOR_Report.php
@@ -1237,14 +1237,9 @@ class AOR_Report extends Basic
             while ($row = $this->db->fetchByAssoc($result)) {
                 $field = BeanFactory::newBean('AOR_Fields');
                 $field->retrieve($row['id']);
-
                 $field->label = str_replace(' ', '_', (string) $field->label) . $i;
-
                 $path = unserialize(base64_decode($field->module_path));
-
-                $field_module = $module;
-                
-                $data = $field_module->field_defs[$field->field] ?? [];            
+                $field_module = $module;             
                 $table_alias = $field_module->table_name;
                 $oldAlias = $table_alias;
                 if (!empty($path[0]) && $path[0] != $module->module_dir) {
@@ -1266,6 +1261,7 @@ class AOR_Report extends Basic
                     }
                 }
 
+                $data = $field_module->field_defs[$field->field] ?? [];
 
                 if (!empty($data)){
                     if ($data['type'] == 'relate' && isset($data['id_name'])) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Lines 1245 to 1247 of AOR_Report.php were in the wrong order causing the first iteration of the loop to return an empty $data array which in turn caused the generated query to fail if a custom field was used as the first field:

```
$data = $field_module->field_defs[$field->field] ?? [];

$field_module = $module;
```

I simply inverted the lines and can confirm that reports work properly after applying the fix

```
$field_module = $module;

$data = $field_module->field_defs[$field->field] ?? [];
```

## Motivation and Context
This fix is necessary to correctly manage custom fields when used as first field of a report

## How To Test This
Create a report using a custom field as the first field of the report

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->