### PR TITLE
Fix #625 Ensure that the value in replaceSeparatorsToInternalFormat is string type

### DIFF
--- a/core/app/core/src/lib/services/formatters/number/number-formatter.service.ts
+++ b/core/app/core/src/lib/services/formatters/number/number-formatter.service.ts
@@ -155,6 +155,8 @@ export class NumberFormatter implements Formatter {
     }
 
     replaceSeparatorsToInternalFormat(value: string): string {
+        value = value.toString();
+        
         const decimalSymbol = this.getDecimalsSymbol() || '.';
 
         const formattedValue = this.toInternalFormat(value);


### PR DESCRIPTION
Ensure that the value in replaceSeparatorsToInternalFormat is string type

When change Decimal Symbol and 1000s separator, in some situation value type is a number, not a string

## Description
Chart vertical bar has yAxisTickFormatting option that pass values to formatter service. The "0" of y Axis tick is passed as number in replaceSeparatorsToInternalFormat  function. When change Decimal Symbol, includes function when called on a number type.

## Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [ ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
