### PR TITLE
Fix variable name typo in NavbarHandler.php

### DIFF
--- a/core/backend/Navbar/LegacyHandler/NavbarHandler.php
+++ b/core/backend/Navbar/LegacyHandler/NavbarHandler.php
@@ -149,16 +149,16 @@ class NavbarHandler extends LegacyHandler implements NavigationProviderInterface
         $accessibleModulesNameMap = $this->createFrontendNameMap($accessibleModules);
         $displayModules = $this->getDisplayEnabledModules();
 
-        $displayModulesMameMap = [];
+        $displayModulesNameMap = [];
 
         foreach ($displayModules as $module => $value) {
             if (isset($accessibleModulesNameMap[$module])) {
-                $displayModulesMameMap[$module] = $accessibleModulesNameMap[$module];
+                $displayModulesNameMap[$module] = $accessibleModulesNameMap[$module];
             }
         }
 
-        $navbar->tabs = array_values($displayModulesMameMap);
-        $navbar->groupedTabs = $this->fetchGroupedNavTabs($displayModules, $displayModulesMameMap);
+        $navbar->tabs = array_values($displayModulesNameMap);
+        $navbar->groupedTabs = $this->fetchGroupedNavTabs($displayModules, $displayModulesNameMap);
 
         $navbar->modules = $this->buildModuleInfo($sugarView, $accessibleModulesNameMap);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

Fixes a typo in a variable name in `NavbarHandler.php`:

```plain
$displayModulesMameMap → $displayModulesNameMap
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

No functional changes, however it makes it less error prone when searching for this variable name, for example.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

Regression test navbar.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->