### PR TITLE
Fix: avoid count() crash in ImportListView on non-array headerColumns

### DIFF
--- a/public/legacy/modules/Import/views/ImportListView.php
+++ b/public/legacy/modules/Import/views/ImportListView.php
@@ -129,6 +129,7 @@ class ImportListView
         $this->ss->assign('pageData', $this->generatePaginationData());
         $this->ss->assign('tableID', $this->tableID);
         $this->ss->assign('colCount', count($this->headerColumns));
+        $this->ss->assign('colCount', is_array($this->headerColumns) ? count($this->headerColumns) : 0);
         $this->ss->assign('APP', $app_strings);
         $this->ss->assign('rowColor', array('oddListRow', 'evenListRow'));
         $this->ss->assign('displayColumns', $this->headerColumns);


### PR DESCRIPTION
This PR fixes a potential fatal error that occurs during the import process when $headerColumns is not an array.

In ImportListView.php, the following line:

$this->ss->assign('colCount', count($this->headerColumns));

can throw an error like:

Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, bool given

This usually happens if something goes wrong earlier in the import process and $headerColumns ends up being false or unset.

Motivation and Context
This change ensures that the import view doesn't break if $headerColumns isn’t an array. It's a small defensive coding fix, but it improves stability for users importing large or complex datasets.


How To Test This
Go to the Import section for the Targets module.

Try importing a large or malformed CSV file.

Confirm that the page doesn’t crash with a count() error.

Verify that the number of columns is displayed correctly if $headerColumns is valid.

Types of changes
 Bug fix (non-breaking change which fixes an issue)


