### PR TITLE
Fix #664 - Ldap Autocreate extra fields

### DIFF
--- a/core/backend/Security/Ldap/AppLdapUserProvider.php
+++ b/core/backend/Security/Ldap/AppLdapUserProvider.php
@@ -159,7 +159,11 @@ class AppLdapUserProvider implements UserProviderInterface, PasswordUpgraderInte
         $userInfo = [];
         foreach ($this->ldapAutoCreateExtraFieldsMap as $ldapKey => $fieldKey) {
             if (isset($extraFields[$ldapKey])) {
-                $userInfo[$fieldKey] = $extraFields[$ldapKey];
+                if(is_array($extraFields[$ldapKey])){
+                    $userInfo[$fieldKey] = $extraFields[$ldapKey][0] ?? '';
+                } else {
+                    $userInfo[$fieldKey] = $extraFields[$ldapKey];
+                }
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
LDAP autocreate function returns extra fields as an array instead of a string since the latest Symfony update to ldap authentication, this causes a failure to save the new User bean.

This fix checks for an array when parsing the extra fields

https://github.com/salesagility/SuiteCRM-Core/issues/664
```
request.CRITICAL: Uncaught PHP Exception TypeError: "html_entity_decode(): Argument #1 ($string) must be of type string, array given" at SugarEmailAddress.php line 1082
```

## Motivation and Context
LDAP autocreate no longer functions after updates to Symfony

## How To Test This
1. Enable ldap authentication
2. Try to login as a user that isn't already a User in SuiteCRM
3. Login fails and new User is not created

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->