### PR TITLE
Fix Api Access issue in SuiteCRM 8

### DIFF
--- a/core/backend/Routes/Service/LegacyApiRedirectHandler.php
+++ b/core/backend/Routes/Service/LegacyApiRedirectHandler.php
@@ -100,7 +100,12 @@ class LegacyApiRedirectHandler extends LegacyRedirectHandler
                 $base = $_SERVER['BASE'] ?? $_SERVER['REDIRECT_BASE'] ?? '';
 
                 $scriptName = $base . '/legacy/' . $info['dir'] . '/' . $info['file'];
-                $requestUri = str_replace($base, $base . '/legacy', $_SERVER['REQUEST_URI']);
+
+                if (!empty($base)) {
+                    $requestUri = str_replace($base, $base . '/legacy', $_SERVER['REQUEST_URI']);
+                } else {
+                    $requestUri = '/legacy' . $_SERVER['REQUEST_URI'];
+                }
 
                 $info['script-name'] = $scriptName;
                 $info['request-uri'] = $requestUri;

--- a/public/legacy/service/core/webservice.php
+++ b/public/legacy/service/core/webservice.php
@@ -48,7 +48,7 @@ if (!defined('sugarEntry') || !sugarEntry) {
  */
 ob_start();
 chdir(__DIR__.'/../../');
-require('include/entryPoint.php');
+require_once('include/entryPoint.php');
 require_once('soap/SoapError.php');
 require_once('SoapHelperWebService.php');
 require_once('SugarRestUtils.php');


### PR DESCRIPTION
## Description
Accessing the V8 and V4 API within SuiteCRM 8 when using a domain that does not include a sub directory to access the CRM would fail with page not found, additionally when getting access to the V4 API it would give a fatal error

## Motivation and Context
Fix Api Access issue in SuiteCRM 8

## How To Test This
Set up a test instance using a domain without a subdirectory or otherwise and see that you can now hit the V8 and V4 API respectively

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->