### PR TITLE
Fix #638 - Exception viewing Symfony Profiler

### DIFF
--- a/core/backend/Routes/Service/LegacyNonViewActionRedirectHandler.php
+++ b/core/backend/Routes/Service/LegacyNonViewActionRedirectHandler.php
@@ -84,6 +84,10 @@ class LegacyNonViewActionRedirectHandler extends LegacyRedirectHandler
             return true;
         }
 
+        if ($request->getPathInfo() === '/_fragment') {
+            return false;
+        }
+
         $isRegistered = true;
         try {
             $this->router->matchRequest($request);


### PR DESCRIPTION
## Description
When running in Dev mode the Symphony toolbar displays as expected, however when using the links to access the profiler view, you would be met with an exception 

## Motivation and Context
Fix #638,  thanks to @advocotek for the suggested solution

## How To Test This

1. Set up an instance running in Dev mode
2. Using the request tab on the Symphony Dev bar at the bottom of the screen
3. Select to access the the profiler using 1 of the profile links
4. And see that you can now access the profiler as expected


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->