### PR TITLE
Fix #689 - Fixed invalid import of ItemNotFoundException

### DIFF
--- a/core/backend/Data/LegacyHandler/PresetListDataHandlers.php
+++ b/core/backend/Data/LegacyHandler/PresetListDataHandlers.php
@@ -28,7 +28,7 @@
 
 namespace App\Data\LegacyHandler;
 
-use ApiPlatform\Core\Exception\ItemNotFoundException;
+use ApiPlatform\Exception\ItemNotFoundException;
 
 class PresetListDataHandlers
 {

--- a/core/backend/Engine/Service/ActionAvailabilityChecker/ActionAvailabilityChecker.php
+++ b/core/backend/Engine/Service/ActionAvailabilityChecker/ActionAvailabilityChecker.php
@@ -27,7 +27,7 @@
 
 namespace App\Engine\Service\ActionAvailabilityChecker;
 
-use ApiPlatform\Core\Exception\ItemNotFoundException;
+use ApiPlatform\Exception\ItemNotFoundException;
 
 class ActionAvailabilityChecker
 {

--- a/core/backend/Process/Service/ProcessHandlerRegistry.php
+++ b/core/backend/Process/Service/ProcessHandlerRegistry.php
@@ -29,7 +29,7 @@
 
 namespace App\Process\Service;
 
-use ApiPlatform\Core\Exception\ItemNotFoundException;
+use ApiPlatform\Exception\ItemNotFoundException;
 
 class ProcessHandlerRegistry
 {

--- a/core/backend/Statistics/Service/StatisticsProviderRegistry.php
+++ b/core/backend/Statistics/Service/StatisticsProviderRegistry.php
@@ -28,7 +28,7 @@
 
 namespace App\Statistics\Service;
 
-use ApiPlatform\Core\Exception\ItemNotFoundException;
+use ApiPlatform\Exception\ItemNotFoundException;
 
 class StatisticsProviderRegistry
 {

--- a/core/backend/SystemConfig/LegacyHandler/SystemConfigHandler.php
+++ b/core/backend/SystemConfig/LegacyHandler/SystemConfigHandler.php
@@ -27,7 +27,7 @@
 
 namespace App\SystemConfig\LegacyHandler;
 
-use ApiPlatform\Core\Exception\ItemNotFoundException;
+use ApiPlatform\Exception\ItemNotFoundException;
 use App\Currency\LegacyHandler\CurrencyHandler;
 use App\Engine\LegacyHandler\LegacyHandler;
 use App\Engine\LegacyHandler\LegacyScopeState;

--- a/core/backend/SystemConfig/LegacyHandler/SystemConfigMappers.php
+++ b/core/backend/SystemConfig/LegacyHandler/SystemConfigMappers.php
@@ -27,7 +27,7 @@
 
 namespace App\SystemConfig\LegacyHandler;
 
-use ApiPlatform\Core\Exception\ItemNotFoundException;
+use ApiPlatform\Exception\ItemNotFoundException;
 
 class SystemConfigMappers
 {

--- a/core/backend/UserPreferences/LegacyHandler/UserPreferenceHandler.php
+++ b/core/backend/UserPreferences/LegacyHandler/UserPreferenceHandler.php
@@ -27,7 +27,7 @@
 
 namespace App\UserPreferences\LegacyHandler;
 
-use ApiPlatform\Core\Exception\ItemNotFoundException;
+use ApiPlatform\Exception\ItemNotFoundException;
 use App\UserPreferences\Entity\UserPreference;
 use App\Engine\LegacyHandler\LegacyHandler;
 use App\Engine\LegacyHandler\LegacyScopeState;

--- a/core/backend/UserPreferences/LegacyHandler/UserPreferencesMappers.php
+++ b/core/backend/UserPreferences/LegacyHandler/UserPreferencesMappers.php
@@ -27,7 +27,7 @@
 
 namespace App\UserPreferences\LegacyHandler;
 
-use ApiPlatform\Core\Exception\ItemNotFoundException;
+use ApiPlatform\Exception\ItemNotFoundException;
 
 class UserPreferencesMappers
 {

--- a/tests/unit/core/legacy/AppListStringsHandlerTest.php
+++ b/tests/unit/core/legacy/AppListStringsHandlerTest.php
@@ -28,7 +28,7 @@
 
 namespace App\Tests\unit\core\legacy;
 
-use ApiPlatform\Core\Exception\ItemNotFoundException;
+use ApiPlatform\Exception\ItemNotFoundException;
 use App\Languages\Entity\AppListStrings;
 use App\Languages\LegacyHandler\AppListStringsHandler;
 use App\Tests\UnitTester;

--- a/tests/unit/core/legacy/AppStringsHandlerTest.php
+++ b/tests/unit/core/legacy/AppStringsHandlerTest.php
@@ -28,7 +28,7 @@
 
 namespace App\Tests\unit\core\legacy;
 
-use ApiPlatform\Core\Exception\ItemNotFoundException;
+use ApiPlatform\Exception\ItemNotFoundException;
 use App\Languages\Entity\AppStrings;
 use App\Tests\UnitTester;
 use Codeception\Test\Unit;

--- a/tests/unit/core/legacy/ModStringsHandlerTest.php
+++ b/tests/unit/core/legacy/ModStringsHandlerTest.php
@@ -28,7 +28,7 @@
 
 namespace App\Tests\unit\core\legacy;
 
-use ApiPlatform\Core\Exception\ItemNotFoundException;
+use ApiPlatform\Exception\ItemNotFoundException;
 use App\Languages\Entity\ModStrings;
 use App\Tests\UnitTester;
 use Codeception\Test\Unit;

--- a/tests/unit/core/legacy/SystemConfig/SystemConfigMappersTest.php
+++ b/tests/unit/core/legacy/SystemConfig/SystemConfigMappersTest.php
@@ -28,7 +28,7 @@
 
 namespace App\Tests\unit\core\legacy\SystemConfig;
 
-use ApiPlatform\Core\Exception\ItemNotFoundException;
+use ApiPlatform\Exception\ItemNotFoundException;
 use App\Module\LegacyHandler\ModuleNameMapperHandler;
 use App\SystemConfig\LegacyHandler\DefaultModuleConfigMapper;
 use App\SystemConfig\LegacyHandler\SystemConfigMappers;

--- a/tests/unit/core/legacy/SystemConfigHandlerTest.php
+++ b/tests/unit/core/legacy/SystemConfigHandlerTest.php
@@ -28,7 +28,7 @@
 
 namespace App\Tests\unit\core\legacy;
 
-use ApiPlatform\Core\Exception\ItemNotFoundException;
+use ApiPlatform\Exception\ItemNotFoundException;
 use App\Engine\LegacyHandler\ActionNameMapperHandler;
 use App\Routes\LegacyHandler\ClassicViewRoutingExclusionsHandler;
 use App\Currency\LegacyHandler\CurrencyHandler;

--- a/tests/unit/core/legacy/UserPreferencesHandlerTest.php
+++ b/tests/unit/core/legacy/UserPreferencesHandlerTest.php
@@ -28,7 +28,7 @@
 
 namespace App\Tests\unit\core\legacy;
 
-use ApiPlatform\Core\Exception\ItemNotFoundException;
+use ApiPlatform\Exception\ItemNotFoundException;
 use App\Tests\UnitTester;
 use AspectMock\Test;
 use Codeception\Test\Unit;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Replaced all incorrect occurrences of:

`use ApiPlatform\Core\Exception\ItemNotFoundException;`
with the correct:

`use ApiPlatform\Exception\ItemNotFoundException;`
The wrong namespace caused ItemNotFoundException to be thrown when registering multiple Process Handlers for the same module (e.g., Leads). This fix ensures correct exception handling and consistent imports.



## Motivation and Context
The incorrect import prevented the invocation of a second Process Handler in the Leads module and potentially other modules, despite the getProcessType() method being called. Correcting the namespace resolves the error and restores expected functionality.

## How To Test This
Create a Process Handler for the Leads module (e.g., record-lead-update-status).

Verify it registers successfully.

Create a second Process Handler for the Leads module (e.g., record-lead-update-next-steps).

Before fix: second handler fails with ItemNotFoundException.

After fix: both handlers register and work as expected.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x]   My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x]  I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
