### PR TITLE
Update SugarCacheRedis.php to allow Secured Redis with AUTH

### DIFF
--- a/public/legacy/include/SugarCache/SugarCacheRedis.php
+++ b/public/legacy/include/SugarCache/SugarCacheRedis.php
@@ -57,6 +57,16 @@ class SugarCacheRedis extends SugarCacheAbstract
     protected $_port = 6379;
     
     /**
+     * @var Redis password string
+     */
+    protected $_password = '';
+    
+    /**
+     * @var Redis database number int
+     */
+    protected $_database = 0;
+    
+    /**
      * @var Redis object
      */
     protected $_redis = null;
@@ -102,8 +112,16 @@ class SugarCacheRedis extends SugarCacheAbstract
                 $this->_redis = new Redis();
                 $this->_host = SugarConfig::getInstance()->get('external_cache.redis.host', $this->_host);
                 $this->_port = SugarConfig::getInstance()->get('external_cache.redis.port', $this->_port);
+                $this->_password = SugarConfig::getInstance()->get('external_cache.redis.password', $this->_password);
+                $this->_database = SugarConfig::getInstance()->get('external_cache.redis.database', $this->_database);
                 if (!$this->_redis->connect($this->_host, $this->_port)) {
                     return false;
+                }
+                if (!empty($this->_password)) {
+                    $this->_redis->auth($this->_password);
+                }
+                if ($this->_database > 0) {
+                    $this->_redis->select($this->_database);
                 }
             }
         } catch (RedisException $e) {


### PR DESCRIPTION
Added Redis Authentication for secured Redis installations, along with database selection.


## Description
This change enables authentication with Redis/Valkey for extra security.

## Motivation and Context
This solves security with Redis/Valkey in case of multiple users.

## How To Test This
After updating to this version of SugarCacheRedis.php update your config_override.php file with the following:

$sugar_config['external_cache']['redis']['host'] = 'localhost';
$sugar_config['external_cache']['redis']['port'] = 6379;
$sugar_config['external_cache']['redis']['password'] = 'PASSWORD';
$sugar_config['external_cache']['redis']['database'] = 1;
$sugar_config['external_cache_disabled_redis'] = false;

Clear your cache and check your Redis/Valkey for populated values.

## Types of changes

- [X] New feature (non-breaking change which adds functionality)


### Final checklist

- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [X] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

