### PR TITLE
Issue-716 - check for duplicate system label

### DIFF
--- a/public/legacy/modules/DynamicFields/language/en_us.lang.php
+++ b/public/legacy/modules/DynamicFields/language/en_us.lang.php
@@ -90,6 +90,7 @@ $mod_strings = array(
     'ERR_RESERVED_FIELD_NAME' => "Reserved Keyword",
     'ERR_SELECT_FIELD_TYPE' => 'Please Select a Field Type',
     'ERR_FIELD_NAME_ALREADY_EXISTS' => 'Field Name already exists',
+    'ERR_LABEL_NAME_ALREADY_EXISTS' => 'Label already exists',
     'LBL_BTN_ADD' => 'Add',
     'LBL_BTN_EDIT' => 'Edit',
     'LBL_GENERATE_URL' => 'Generate URL',

--- a/public/legacy/modules/DynamicFields/templates/Fields/Forms/coreTop.tpl
+++ b/public/legacy/modules/DynamicFields/templates/Fields/Forms/coreTop.tpl
@@ -67,6 +67,7 @@
 		addToValidateIsInArray('popup_form', 'name', 'in_array', true,'{sugar_translate module="DynamicFields" label="ERR_RESERVED_FIELD_NAME"}', '{$field_name_exceptions}', 'u==');
 		{if $hideLevel == 0}	
 		addToValidateIsInArray('popup_form', 'name', 'in_array', true, '{sugar_translate module="DynamicFields" label="ERR_FIELD_NAME_ALREADY_EXISTS"}', '{$existing_field_names}', 'u==');
+		addToValidateIsInArray('popup_form', 'label_key_id', 'in_array', true, '{sugar_translate module="DynamicFields" label="ERR_LABEL_NAME_ALREADY_EXISTS"}', '{$existing_label_names}', 'u==');
 		{/if}	
 		</script>
 	</td>

--- a/public/legacy/modules/ModuleBuilder/views/view.modulefield.php
+++ b/public/legacy/modules/ModuleBuilder/views/view.modulefield.php
@@ -325,7 +325,8 @@ class ViewModulefield extends SugarView
         $fv->ss->assign('duplicate_merge_options', $GLOBALS['app_list_strings']['custom_fields_merge_dup_dom'] ?? []);
 
         $triggers = array() ;
-        $existing_field_names = array() ;
+        $existing_field_names = array();
+        $existing_label_names = array();
         foreach ($module->mbvardefs->vardefs['fields'] as $field) {
             if ($field [ 'type' ] == 'enum' || $field [ 'type'] == 'multienum') {
                 $triggers [] = $field [ 'name' ] ;
@@ -336,10 +337,16 @@ class ViewModulefield extends SugarView
                     $existing_field_names [] = strtoupper($matches[1]);
                 }
             }
+
+            if(!empty($field['vname']))
+            {
+                $existing_label_names[] = $field['vname'];
+            }
         }
         
         $fv->ss->assign('triggers', $triggers);
         $fv->ss->assign('existing_field_names', $json->encode($existing_field_names));
+        $fv->ss->assign('existing_label_names', $json->encode($existing_label_names));
         $fv->ss->assign('mod_strings', $GLOBALS['mod_strings']);
 
         // jchi #24880


### PR DESCRIPTION
Create a new warning in studio for duplicate system labels when creating a new field.

## Description
The same system label could potentially be used for more than one field. When creating a new field with a used system label, the new display label overwrites the old one, changing the display label for both fields.
A warning now appears on the form if the system label already exists in the module when attempting to create a new field. The field will not be created in this scenario.
Issue here: https://github.com/SuiteCRM/SuiteCRM-Core/issues/716

## Motivation and Context
Two fields had the same system label. One field's display label was changed to the newly create one as a result.

## How To Test This
See https://github.com/SuiteCRM/SuiteCRM-Core/issues/716

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.