### PR TITLE
Fixes bug not importing email subject

### DIFF
--- a/public/legacy/modules/InboundEmail/InboundEmail.php
+++ b/public/legacy/modules/InboundEmail/InboundEmail.php
@@ -5495,7 +5495,7 @@ class InboundEmail extends SugarBean
             ////	ASSIGN APPROPRIATE ATTRIBUTES TO NEW EMAIL OBJECT
             // handle UTF-8/charset encoding in the ***headers***
 
-            $email->name = purify_html($this->handleMimeHeaderDecode($parsedFullHeader->subject));
+            $email->name = purify_html($this->handleMimeHeaderDecode($header->subject));
             $email->type = 'inbound';
             if (!empty($unixHeaderDate)) {
                 $email->date_sent_received = $timedate->asUser($unixHeaderDate);


### PR DESCRIPTION
fixes bug - not saving subject when importing email


## Description
SuiteCRM 8.9.0 (and previous) not importing email subject

<img width="784" height="213" alt="Schermata 2025-09-22 alle 14 22 50" src="https://github.com/user-attachments/assets/9a941138-4aa7-4871-baee-8fbcb8f4e6ed" />


## Motivation and Context
simply solves the problem of importing correctly email subject in history

## How To Test This
tested in live environment

## Types of changes

- [x ] Bug fix (non-breaking change which fixes an issue)


