### PR TITLE
Update in_queue_date to use current DateTime format

### DIFF
--- a/core/modules/Campaigns/Service/Email/Queue/DefaultEmailQueueManager.php
+++ b/core/modules/Campaigns/Service/Email/Queue/DefaultEmailQueueManager.php
@@ -212,13 +212,13 @@ class DefaultEmailQueueManager implements EmailQueueManagerInterface
         $queryBuilder = $this->preparedStatementHandler->createQueryBuilder();
 
         $queryBuilder->update('emailman')
-                     ->set('in_queue', ':in_queue')
-                     ->set('send_attempts', 'send_attempts + 1')
-                     ->set('in_queue_date', ':in_queue_date')
-                     ->where('id = :id')
-                     ->setParameter('in_queue', '1')
-                     ->setParameter('in_queue_date', $timedate->now())
-                     ->setParameter('id', $id);
+            ->set('in_queue', ':in_queue')
+            ->set('send_attempts', 'send_attempts + 1')
+            ->set('in_queue_date', ':in_queue_date')
+            ->where('id = :id')
+            ->setParameter('in_queue', '1')
+            ->setParameter('in_queue_date', (new \DateTime())->format('Y-m-d H:i:s'))
+            ->setParameter('id', $id);
 
         try {
             $queryBuilder->executeStatement();


### PR DESCRIPTION
Bugfix for email campaign block

## Description
simple update for a datetime error:

## Motivation and Context
error log example:
SQLSTATE[22007]: Invalid datetime format: 1292 Incorrect datetime value: '28/10/2025 14:05' for column

## How To Test This
you can't send programmed email campaign

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

