### PR TITLE
Fix #795 – Report fails with blank screen when using date field filters containing plus or minus values

### DIFF
--- a/public/legacy/modules/AOR_Reports/AOR_Report.php
+++ b/public/legacy/modules/AOR_Reports/AOR_Report.php
@@ -1628,7 +1628,11 @@ class AOR_Report extends Basic
                             break;
 
                         case 'Date':
-                            $params = unserialize(base64_decode($condition->value),['allowed_classes' => false]);
+                            if(is_array($condition->value)) {
+                                $params = $condition->value;
+                            } else {
+                                $params = unserialize(base64_decode($condition->value),['allowed_classes' => false]);
+                            }
 
                             // Fix for issue #1272 - AOR_Report module cannot update Date type parameter.
                             if ($params == false) {


### PR DESCRIPTION

Fix SuiteCRM/SuiteCRM#10744 – Report fails with blank screen when using date field filters containing plus or minus values

<!--- Provide a general summary of your changes in the Title above -->

## Description
This fix resolves a fatal error that occurs when running a report with a date-type field filter using relative values such as “Today +7 days” or “Today -30 days.”

Previously, when these filters were applied, the report would fail and display a blank white screen.
Here is the screenshot 
<img width="1462" height="565" alt="image" src="https://github.com/user-attachments/assets/92f4cfdb-4925-4d3a-a528-a0dcaf79a871" />


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
1.Go to Reports module.
2.Create a new report on any module that has a Date field.
3.In the conditions choose the date field and operator as Equal, Type = Date and set a condition value Today using plus or minus (for example, “Date is greater than Today +7 days”).
4. when you click on Update button to retrieve result. 
5. It will show you blank page.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [X] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [X] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->