### PR TITLE
Fix #707 - Date filter in list views with today/yesterday/etc options

### DIFF
--- a/core/backend/ViewDefinitions/LegacyHandler/SearchDefs/SearchDefsDateTypeMapper.php
+++ b/core/backend/ViewDefinitions/LegacyHandler/SearchDefs/SearchDefsDateTypeMapper.php
@@ -205,7 +205,7 @@ class SearchDefsDateTypeMapper implements ViewDefinitionMapperInterface
                 continue;
             }
 
-            $enableRangeSearch = $field['enable_range_search'] ?? false;
+            $enableRangeSearch = $field['enable_range_search'] ?? $field['fieldDefinition']['enable_range_search'] ?? false;
 
             if ($enableRangeSearch === 0 || $enableRangeSearch === false || $enableRangeSearch === '0' || $enableRangeSearch === 'false') {
                 continue;


### PR DESCRIPTION
## Description

Fixed `SearchDefsDateTypeMapper` to properly resolve `enable_range_search` configuration for date fields in list view searches.

**Change:** Added fallback to check `fieldDefinition['enable_range_search']` when field-level value is not set.

- **Before:** Only checked `$field['enable_range_search']`, ignoring nested definition
- **After:** Checks `$field['enable_range_search']` first, falls back to `$field['fieldDefinition']['enable_range_search']`, then defaults to false
- **Result:** Date filter options (today, yesterday, last 7 days, etc.) now appear correctly in Suite 8 list views

**File Changed:** `core/backend/ViewDefinitions/LegacyHandler/SearchDefs/SearchDefsDateTypeMapper.php`

Fixes #707

## Motivation and Context

This change fixes a regression from SuiteCRM 7 where date filter preset options (Today, Yesterday, Last 7 Days, Last 30 Days, Between, etc.) were missing in Suite 8 list view filters.

**Root Cause:** In SuiteCRM 8, date field definitions can specify `enable_range_search` at two levels:
1. Search field level: `searchdefs[$field]['enable_range_search']`
2. Field definition level: `vardefs[$field]['enable_range_search']`

The original code only checked level 1, causing fields with only level 2 configuration to incorrectly skip range search functionality. Suite 7 handled this correctly by checking both levels.

## How To Test This

### Prerequisites
1. Clear Suite 8 cache after applying changes
2. Verify test module has date fields with `enable_range_search` enabled in vardefs

### Test Steps
1. Navigate to a module list view with date fields (e.g., Meetings, Calls, Tasks)
2. Click the filter/search icon to open the filter panel
3. Click on a date field filter dropdown
4. **Expected:** Verify preset options appear:
   - Today, Yesterday, Last 7 Days, Last 30 Days, etc.
   - Between (shows start/end date pickers)
5. Select "Today" preset and apply filter
6. **Expected:** List view shows only records with today's date in that field
7. Select "Between" operator
8. **Expected:** Start and end date pickers appear
9. Select date range and apply
10. **Expected:** List view shows records within that date range

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
