### PR TITLE
Fix #708 #637 - Date field default value not working

### DIFF
--- a/core/backend/Process/Service/FieldDefault/DateFieldDefaultCalculation.php
+++ b/core/backend/Process/Service/FieldDefault/DateFieldDefaultCalculation.php
@@ -107,6 +107,7 @@ class DateFieldDefaultCalculation extends LegacyHandler implements ProcessHandle
         $displayDefault = $options['displayDefault'];
 
         $this->init();
+        $this->startLegacyApp();
 
         /* @noinspection PhpIncludeInspection */
         require_once 'include/portability/Services/DateTime/DateTimeService.php';


### PR DESCRIPTION

## Description

This PR fixes two related issues where date fields with default values (today/yesterday) either appear blank or fail format validation during record creation.

**Root cause:** The `DateFieldDefaultCalculation` service uses the legacy `DateTimeService` which requires proper initialization of legacy dependencies (user preferences, global state like `$current_user` and `$timedate`). Previously, only `init()` was called, leaving these dependencies unavailable.

**Solution:** Added `$this->startLegacyApp()` call after `$this->init()` in the `DateFieldDefaultCalculation::run()` method to ensure proper loading of legacy dependencies required for date format conversion.

**Technical change:** Single line addition at line 110 in `core/backend/Process/Service/FieldDefault/DateFieldDefaultCalculation.php`

**Fixes:**
- #637: Date fields with defaults (today/yesterday) appear blank on new records and produce "invalid date format" validation errors when saving (SuiteCRM 8.8.0)
- #708: Date field default values work with `m/d/Y` format but fail when user profile uses other formats like `d.m.Y` (SuiteCRM 8.9 beta)

## Motivation and Context

Users cannot reliably use date field default values in Studio-created fields because:
1. Optional date fields with defaults appear blank and fail validation on save (#637)
2. Default values only work with US date format (`m/d/Y`), breaking for international date formats (#708)

This prevents users from:
- Setting up automated workflows that require date tracking
- Using Studio to create date fields with sensible defaults
- Supporting international users with non-US date preferences

The fix ensures date format conversion works correctly by initializing the legacy app context before invoking legacy date services.

## How To Test This

### Test Case 1: Non-US Date Format (#708)
1. In Studio, add a date field to any module with default value "today"
2. Go to your user profile and set date format to `d.m.Y` (or `d/m/Y`)
3. Create a new record in that module
4. **Expected:** Date field displays today's date in `d.m.Y` format
5. Save the record
6. **Expected:** Save succeeds without validation errors

### Test Case 2: Optional Date Field with Default (#637)
1. In Studio, add a date field to Target Lists module:
   - Label: "Last Send Date"
   - Default Value: "yesterday"
   - Required: No (unchecked)
2. Add field to Detail View layout
3. Save and deploy
4. Navigate to Target Lists → Create
5. **Expected:** "Last Send Date" field shows yesterday's date
6. Save the record without modifying the date field
7. **Expected:** Save succeeds without "invalid date format" error

### Test Case 3: Regression - US Date Format
1. Set your user profile date format to `m/d/Y`
2. Create a new record in a module with a date field default
3. **Expected:** Date field shows default in `m/d/Y` format
4. Save successfully
5. **Expected:** No regression from existing functionality

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.
