### PR TITLE
Add missing docstring parameter

### DIFF
--- a/core/backend/Navbar/LegacyHandler/NavbarHandler.php
+++ b/core/backend/Navbar/LegacyHandler/NavbarHandler.php
@@ -100,6 +100,7 @@ class NavbarHandler extends LegacyHandler implements NavigationProviderInterface
      * @param RequestStack $session
      * @param array $moduleRouting
      * @param array $navbarAdministrationOverrides
+     * @param array $navbarOverrides
      * @param array $quickActions
      */
     public function __construct(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

SuiteCRM 8.9 added this class member in NavbarHandler.php:

```php
/**
 * @var array
 */
protected $navbarOverrides;
```

Commit: https://github.com/SuiteCRM/SuiteCRM-Core/commit/a387c6b929edbb5377bb021885aaf5caac8f662d

However it was missed to be added to the list of constructor docstring parameters.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This missing docstring parameter misaligns the list of docstring parameters with the actual constructor parameters.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Documentation change

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->