### PR TITLE
Fix #695 image field in users modules comes with an extra "10"

### DIFF
--- a/public/legacy/include/SugarFields/Fields/Image/DetailView.tpl
+++ b/public/legacy/include/SugarFields/Fields/Image/DetailView.tpl
@@ -42,6 +42,6 @@
 {if !isset({{sugarvar key='value' string=true}})}
     <img src="" style="max-width: {if !$vardef.width}{{$vardef.width}}{else}200{/if}px;" height="{if !$vardef.height}{{$vardef.height}}{else}50{/if}">
 {else}
-    <img src="index.php?entryPoint=download&id={$fields.{{$vardef.fileId}}.value|default:''}_{{if empty($displayParams.idName)}}{{sugarvar key='name'}}{{else}}{{$displayParams.idName}}{{/if}}{$fields.width.value|default:10}&type={{$vardef.linkModule|default:''}}" style="max-width: {if isset($vardef.width)}{{$vardef.width}}{else}200{/if}px;" height="{if isset($vardef.height)}{{$vardef.height}}{else}50{/if}">
+    <img src="index.php?entryPoint=download&id={$fields.{{$vardef.fileId}}.value|default:''}_{{if empty($displayParams.idName)}}{{sugarvar key='name'}}{{else}}{{$displayParams.idName}}{{/if}}&type={{$vardef.linkModule|default:''}}" style="max-width: {if isset($vardef.width)}{{$vardef.width}}{else}200{/if}px;" height="{if isset($vardef.height)}{{$vardef.height}}{else}50{/if}">
 {/if}
 </span>


### PR DESCRIPTION
Photo is broken in user profile, the problem with src of img tag having extra "10" at the end of url
the issue is in `legacy/include/SugarFields/Fields/Image/DetailView.tpl`

Fix #695 image field in users modules comes with an extra "10" There is no need of `{$fields.width.value|default:10}` in line
```<img src="index.php?entryPoint=download&id={$fields.{{$vardef.fileId}}.value|default:''}_{{if empty($displayParams.idName)}}{{sugarvar key='name'}}{{else}}{{$displayParams.idName}}{{/if}}{$fields.width.value|default:10}&type={{$vardef.linkModule|default:''}}" style="max-width: {if isset($vardef.width)}{{$vardef.width}}{else}200{/if}px;" height="{if isset($vardef.height)}{{$vardef.height}}{else}50{/if}">```

Even if you add &width= the default value is set to 10 which is too less and image will not be shown properly We can see the previous img tag in if block with `src=""` has height attribute but width is set in style tag there is no width attribute added, if we follow same in else block as well then there is no need of `{$fields.width.value|default:10}` and can be removed directly.

Though this $fields.width.value was there since years the issue coming because of default value set to 10 while adding support to php 8.3

<!--- Provide a general summary of your changes in the Title above -->

## Description
Removed unwanted code `{$fields.width.value|default:10}` which is not required at that place.
To reproduce this issue go to users profile, upload an image if not there already and see users detail view or users profile
This issue can be reproduce by adding any custom image field and add it in detail view, the image src will show additional 10 at the end of src url because this issue with core file of SugarFields Image DetailView.

The issue is reported here   #695 this change will fix this issue


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This chage will solve the detailview preview of all fields with SugarField type image, currently the image is broken in detailview because of additional "10" at the end of url

## How To Test This
<!--- Please describe in detail how to test your changes. -->
Go to your profile page detail view or open any users detailview, and look for photo field, the image will be shown broken and if you look for the image url with download entrypoint the you can see additional 10 at the end of id param

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->