### PR TITLE
Persist legacy emails_text recipients for outbound compose sends

### DIFF
--- a/core/backend/Emails/LegacyHandler/EmailProcessProcessor.php
+++ b/core/backend/Emails/LegacyHandler/EmailProcessProcessor.php
@@ -125,6 +125,7 @@ class EmailProcessProcessor extends LegacyHandler
         $emailRecord = $this->recordProvider->saveRecord($emailRecord);
 
         $this->saveEmailAddresses($outboundRecord->getAttributes(), $emailRecord->getAttributes(), $addresses);
+        $this->saveEmailText($outboundRecord->getAttributes(), $emailAttributes, $emailRecord->getAttributes(), $addresses);
 
         $this->close();
         return [
@@ -315,6 +316,135 @@ class EmailProcessProcessor extends LegacyHandler
         );
 
         return $attributes;
+    }
+
+    /**
+     * SuiteCRM 8 email compose sends address fields as arrays of entities (multiflexrelate).
+     * Legacy Emails expects string fields in emails_text (to_addrs/cc_addrs/bcc_addrs/from_addr).
+     *
+     * Without this, the email can be sent successfully but legacy list/detail views can show empty or incorrect recipients.
+     *
+     * @param array|null $outboundAttributes
+     * @param array $inputEmailAttributes Attributes as received from the process payload
+     * @param array $savedEmailAttributes Attributes from the saved record (needs id)
+     * @param array $addresses Flattened email address arrays (to/cc/bcc)
+     */
+    protected function saveEmailText(?array $outboundAttributes, array $inputEmailAttributes, array $savedEmailAttributes, array $addresses): void
+    {
+        $emailId = $savedEmailAttributes['id'] ?? '';
+        if (empty($emailId)) {
+            return;
+        }
+
+        $fromAddr = (string)($outboundAttributes['smtp_from_addr'] ?? '');
+        $replyToAddr = (string)($outboundAttributes['reply_to_addr'] ?? '');
+
+        // Prefer the structured input payload for nicer formatting (Name <email>), fallback to flattened lists.
+        $to = $this->formatLegacyAddressList($inputEmailAttributes['to_addrs_names'] ?? null);
+        $cc = $this->formatLegacyAddressList($inputEmailAttributes['cc_addrs_names'] ?? null);
+        $bcc = $this->formatLegacyAddressList($inputEmailAttributes['bcc_addrs_names'] ?? null);
+
+        if ($to === '') {
+            $to = implode(', ', array_filter($addresses['to'] ?? []));
+        }
+        if ($cc === '') {
+            $cc = implode(', ', array_filter($addresses['cc'] ?? []));
+        }
+        if ($bcc === '') {
+            $bcc = implode(', ', array_filter($addresses['bcc'] ?? []));
+        }
+
+        $description = (string)($inputEmailAttributes['description'] ?? '');
+        $descriptionHtml = (string)($inputEmailAttributes['description_html'] ?? '');
+
+        try {
+            // Keep raw_source untouched if it exists (we don't have the full MIME here).
+            $this->preparedStatementHandler->update(
+                'INSERT INTO emails_text (email_id, from_addr, reply_to_addr, to_addrs, cc_addrs, bcc_addrs, description, description_html, raw_source, deleted) ' .
+                'VALUES (:email_id, :from_addr, :reply_to_addr, :to_addrs, :cc_addrs, :bcc_addrs, :description, :description_html, \'\', 0) ' .
+                'ON DUPLICATE KEY UPDATE ' .
+                'from_addr = VALUES(from_addr), ' .
+                'reply_to_addr = VALUES(reply_to_addr), ' .
+                'to_addrs = VALUES(to_addrs), ' .
+                'cc_addrs = VALUES(cc_addrs), ' .
+                'bcc_addrs = VALUES(bcc_addrs), ' .
+                'description = VALUES(description), ' .
+                'description_html = VALUES(description_html)',
+                [
+                    'email_id' => $emailId,
+                    'from_addr' => $fromAddr,
+                    'reply_to_addr' => $replyToAddr,
+                    'to_addrs' => $to,
+                    'cc_addrs' => $cc,
+                    'bcc_addrs' => $bcc,
+                    'description' => $description,
+                    'description_html' => $descriptionHtml,
+                ],
+                [
+                    ['param' => 'email_id', 'type' => 'string'],
+                    ['param' => 'from_addr', 'type' => 'string'],
+                    ['param' => 'reply_to_addr', 'type' => 'string'],
+                    ['param' => 'to_addrs', 'type' => 'string'],
+                    ['param' => 'cc_addrs', 'type' => 'string'],
+                    ['param' => 'bcc_addrs', 'type' => 'string'],
+                    ['param' => 'description', 'type' => 'string'],
+                    ['param' => 'description_html', 'type' => 'string'],
+                ]
+            );
+        } catch (\Throwable $e) {
+            $this->logger->warning('Failed to persist legacy emails_text fields.', [
+                'email_id' => $emailId,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Accepts multiple input formats and returns a legacy string list:
+     * - array of entities: [{name, email1|email}]
+     * - array of strings
+     * - comma/semicolon separated string
+     */
+    protected function formatLegacyAddressList(mixed $value): string
+    {
+        if (empty($value)) {
+            return '';
+        }
+
+        if (is_string($value)) {
+            $parts = preg_split('/[;,]+/', $value) ?: [];
+            $parts = array_map(static fn($s) => trim((string)$s), $parts);
+            $parts = array_filter($parts, static fn($s) => $s !== '');
+            return implode(', ', $parts);
+        }
+
+        if (!is_array($value)) {
+            return '';
+        }
+
+        $out = [];
+        foreach ($value as $item) {
+            if (is_string($item)) {
+                $s = trim($item);
+                if ($s !== '') {
+                    $out[] = $s;
+                }
+                continue;
+            }
+
+            if (!is_array($item)) {
+                continue;
+            }
+
+            $email = (string)($item['email1'] ?? $item['email'] ?? '');
+            $name = trim((string)($item['name'] ?? ''));
+            if ($email === '') {
+                continue;
+            }
+            $out[] = $name !== '' ? ($name . ' <' . $email . '>') : $email;
+        }
+
+        return implode(', ', $out);
     }
 
 }


### PR DESCRIPTION
## Summary

This PR fixes a legacy email persistence gap where outbound emails sent from SuiteCRM 8 compose flow could display incorrect or empty recipient data in legacy **Emails** views.

When the send succeeded, recipients were stored in relational tables, but legacy string fields in `emails_text` (used by list/detail rendering) were not consistently populated.

## Scope

Single file, intentionally minimal:

- `core/backend/Emails/LegacyHandler/EmailProcessProcessor.php`

## Root Cause

`EmailProcessProcessor` saved the email record and address relations, but did not reliably persist legacy text columns used by the classic Emails UI:

- `from_addr`
- `reply_to_addr`
- `to_addrs`
- `cc_addrs`
- `bcc_addrs`
- `description`
- `description_html`

In practice, this could result in detail/list views showing sender-like fallback values instead of actual recipients.

## What Changed

### 1) Persist `emails_text` after send processing

After address relations are saved, the processor now calls:

- `saveEmailText(...)`

This writes or updates `emails_text` with `INSERT ... ON DUPLICATE KEY UPDATE`.

### 2) Robust address formatting for legacy fields

Added helper:

- `formatLegacyAddressList(...)`

It accepts multiple payload formats and normalizes them into legacy comma-separated strings:

- array of entities (`name`, `email1`/`email`)
- array of strings
- comma/semicolon-separated string

### 3) Defensive behavior

- If email id is missing, skip safely.
- If `emails_text` persistence fails, log warning and do not break send flow.
- `raw_source` remains untouched (`''`) because full MIME is not available in this path.

## Behavior

- Sending remains authoritative: send success is not blocked by `emails_text` write failures.
- Legacy Emails list/detail recipient rendering becomes consistent with actual outbound recipients.
- No schema changes.
- No Graph transport changes.
- No UI/frontend changes.

## Validation

- `php -l core/backend/Emails/LegacyHandler/EmailProcessProcessor.php`

## Notes

This PR is intentionally separated from the IMAP Sent append fix PR to keep review scope tight and reduce regression risk.
