### PR TITLE
Fix legacy email folder navigation and archived filter behavior

### DIFF
--- a/public/legacy/include/SugarFolders/SugarFolders.php
+++ b/public/legacy/include/SugarFolders/SugarFolders.php
@@ -1514,12 +1514,35 @@ class SugarFolder
             $folders = $this->getFoldersForSettings($current_user);
         }
 
-        if ($this->shouldFolderDisplay($folders['userFolders'] ?? [], $folderId)) {
-            return true;
-        }
+        // The settings screen selects which *root* folders (inbound accounts / group inboxes)
+        // are displayed. Child folders (e.g. "Sent Emails", monitored IMAP subfolders) are
+        // displayed/selected implicitly when their parent root folder is selected.
+        //
+        // Some parts of the Emails UI navigate by passing a child `folders_id`. If we only
+        // allow direct matches, navigation will fall back to the default inbox folder.
+        $maxDepth = 10;
+        $currentId = $folderId;
 
-        if ($this->shouldFolderDisplay($folders['groupFolders'] ?? [], $folderId)) {
-            return true;
+        for ($i = 0; $i < $maxDepth && !empty($currentId); $i++) {
+            if ($this->shouldFolderDisplay($folders['userFolders'] ?? [], $currentId)) {
+                return true;
+            }
+
+            if ($this->shouldFolderDisplay($folders['groupFolders'] ?? [], $currentId)) {
+                return true;
+            }
+
+            // Walk up the tree (child -> parent). If we can't resolve the parent, stop.
+            $query = "SELECT parent_folder FROM folders WHERE id = " . $this->db->quoted($currentId) . " AND deleted = 0";
+            $r = $this->db->query($query);
+            $row = $this->db->fetchByAssoc($r);
+            $parent = $row['parent_folder'] ?? '';
+
+            if (empty($parent) || $parent === $currentId) {
+                break;
+            }
+
+            $currentId = $parent;
         }
 
         return false;

--- a/public/legacy/modules/Emails/include/ListView/ListViewDataEmails.php
+++ b/public/legacy/modules/Emails/include/ListView/ListViewDataEmails.php
@@ -186,6 +186,11 @@ class ListViewDataEmails extends ListViewData
                 $this->searchType = "crm";
                 break;
 
+            case "archived":
+                // Archived emails are SuiteCRM records (not an IMAP mailbox).
+                $this->searchType = "crm";
+                break;
+
             case "trash":
                 $this->searchType = "imap";
                 break;
@@ -741,6 +746,14 @@ class ListViewDataEmails extends ListViewData
                     $where .= ' AND ';
                 }
                 $where .= ' emails.status LIKE "draft" AND emails.deleted LIKE "0" ';
+            }
+
+            // archived is a CRM-only view (emails.type='archived')
+            if ($folderObj->getType() === 'archived' && !array_key_exists('type', $filter_fields)) {
+                if (!empty($where)) {
+                    $where .= ' AND ';
+                }
+                $where .= ' emails.type LIKE "archived" AND emails.deleted LIKE "0" ';
             }
 
 

--- a/public/legacy/modules/InboundEmail/InboundEmail.php
+++ b/public/legacy/modules/InboundEmail/InboundEmail.php
@@ -6771,8 +6771,19 @@ class InboundEmail extends SugarBean
     public function getUserInboundAccounts(): array {
         global $current_user, $db;
 
+        // Defensive: in some execution paths (e.g. embedded legacy views) $GLOBALS['db'] can be set
+        // while the global `$db` variable is not. Avoid fatals on `$db->quote(...)`.
+        if (!is_object($db) && isset($GLOBALS['db']) && is_object($GLOBALS['db'])) {
+            $db = $GLOBALS['db'];
+        }
+
         $where = '';
         if (is_admin($current_user)) {
+            if (!is_object($db)) {
+                $GLOBALS['log']?->fatal('InboundEmail::getUserInboundAccounts: DB connection not initialised');
+                return [];
+            }
+
             $currentUserId = $db->quote($current_user->id);
             $tableName = $db->quote($this->table_name);
             $where = "(($tableName.is_personal IS NULL) OR ($tableName.is_personal = 0 ) OR ($tableName.is_personal = 1 AND $tableName.created_by = '$currentUserId'))";


### PR DESCRIPTION
## Summary

This PR fixes legacy Emails folder behavior where selected non-inbox folders could fail to load correctly or show unexpected empty results.

It focuses on folder navigation and filtering consistency in the legacy email UI.

## Scope

Intentionally limited to three legacy email files:

- `public/legacy/include/SugarFolders/SugarFolders.php`
- `public/legacy/modules/Emails/include/ListView/ListViewDataEmails.php`
- `public/legacy/modules/InboundEmail/InboundEmail.php`

## Root Causes

1. Folder visibility checks were performed only against the exact selected folder id.  
   If a child folder id was passed (for example Sent/Drafts under a selected account root), the UI could fall back to Inbox.

2. `archived` folder type was not explicitly handled as CRM data in list-view logic.

3. In some legacy execution paths, `InboundEmail::getUserInboundAccounts()` could attempt to use `$db` when only `$GLOBALS['db']` was initialized, causing unstable behavior.

## What Changed

### 1) Parent-aware folder visibility (`SugarFolders.php`)

- Updated folder-display check to walk up parent folders (child -> parent, bounded depth).
- If any ancestor is selected in user/group folder settings, access is allowed.
- Prevents navigation resets when opening child folders such as Sent/Drafts/monitored subfolders.

### 2) Archived folder handling in list view (`ListViewDataEmails.php`)

- Added explicit `archived` search type handling as `crm`.
- Added CRM filter clause for archived folder (`emails.type = 'archived'`).
- Keeps archived view behavior aligned with CRM-stored records.

### 3) Defensive DB initialization (`InboundEmail.php`)

- Added fallback from local `$db` to `$GLOBALS['db']` when needed.
- Added safe return for admin path if DB is still unavailable.
- Avoids fatal errors in edge bootstrap paths.

## Behavior

- Opening child folders under a configured inbound/group account no longer drops back to Inbox due to visibility mismatch.
- Archived folder view resolves through the correct CRM query mode.
- Inbound account lookup is more resilient in legacy contexts with partial global initialization.

## Non-Goals

- No changes to outbound send transport.
- No IMAP Sent append logic changes.
- No schema changes.
- No frontend framework refactors.

## Validation

- `php -l public/legacy/include/SugarFolders/SugarFolders.php`
- `php -l public/legacy/modules/Emails/include/ListView/ListViewDataEmails.php`
- `php -l public/legacy/modules/InboundEmail/InboundEmail.php`

## Notes

This PR is separated from PR-A to keep review scope focused:

- PR-A: recipients persistence in `emails_text`
- PR-B: legacy folder navigation and folder-type query behavior
