### PR TITLE
Fix outbound default selection for personal accounts

### DIFF
--- a/core/modules/EmailMarketing/Service/Fields/InitOutboundEmailDefault.php
+++ b/core/modules/EmailMarketing/Service/Fields/InitOutboundEmailDefault.php
@@ -31,6 +31,7 @@ use App\Data\Service\RecordProviderInterface;
 use App\Process\Entity\Process;
 use App\Process\Service\ProcessHandlerInterface;
 use App\UserPreferences\Service\UserPreferencesProviderInterface;
+use BeanFactory;
 use InvalidArgumentException;
 
 class InitOutboundEmailDefault implements ProcessHandlerInterface
@@ -101,21 +102,12 @@ class InitOutboundEmailDefault implements ProcessHandlerInterface
      */
     public function run(Process $process): void
     {
-
         $preferences = $this->userPreferenceService->getUserPreference('Emails')?->getItems() ?? [];
-
-        if ($preferences === []) {
-            $responseData = [
-                'value' => null,
-            ];
-
-            $process->setStatus('error');
-            $process->setMessages([]);
-            $process->setData($responseData);
-            return;
-        }
-
         $id = $preferences['defaultOEAccount'] ?? '';
+
+        if ($id === '') {
+            $id = $this->getSinglePersonalOutboundId();
+        }
 
         if ($id === '') {
             $responseData = [
@@ -155,5 +147,47 @@ class InitOutboundEmailDefault implements ProcessHandlerInterface
         $process->setStatus('success');
         $process->setMessages([]);
         $process->setData($responseData);
+    }
+
+    protected function getSinglePersonalOutboundId(): string
+    {
+        /** @var \OutboundEmailAccounts $outboundAccount */
+        $outboundAccount = BeanFactory::newBean('OutboundEmailAccounts');
+
+        if (!$outboundAccount || !method_exists($outboundAccount, 'getUserOutboundAccounts')) {
+            return '';
+        }
+
+        $personalOutboundIds = [];
+        $accounts = $outboundAccount->getUserOutboundAccounts();
+
+        foreach ($accounts as $account) {
+            $type = $account->type ?? '';
+            if ($type !== 'user') {
+                continue;
+            }
+
+            $id = $account->id ?? '';
+            if ($id === '') {
+                continue;
+            }
+
+            $fromAddress = trim((string)($account->smtp_from_addr ?? ''));
+            if ($fromAddress === '') {
+                continue;
+            }
+
+            $personalOutboundIds[] = $id;
+
+            if (count($personalOutboundIds) > 1) {
+                return '';
+            }
+        }
+
+        if (count($personalOutboundIds) !== 1) {
+            return '';
+        }
+
+        return $personalOutboundIds[0];
     }
 }

--- a/public/legacy/modules/OutboundEmailAccounts/OutboundEmailAccounts.php
+++ b/public/legacy/modules/OutboundEmailAccounts/OutboundEmailAccounts.php
@@ -162,13 +162,21 @@ class OutboundEmailAccounts extends OutboundEmailAccounts_sugar
             $admin->saveSetting('notify', 'fromaddress', $this->smtp_from_addr);
         }
 
-        $currentOECount = $this->getUserPersonalAccountCount($current_user);
+        $defaultOwner = $current_user;
+        if ($this->type === 'user' && !empty($this->user_id)) {
+            $owner = BeanFactory::getBean('Users', $this->user_id);
+            if (!empty($owner) && !empty($owner->id)) {
+                $defaultOwner = $owner;
+            }
+        }
+
+        $currentOECount = $this->getUserPersonalAccountCount($defaultOwner);
 
         $results = parent::save($check_notify);
 
         //If this is the first personal account the user has setup mark it as default for them.
-        if ($currentOECount === '0') {
-            $this->setUsersDefaultOutboundAccount($current_user, $this->id);
+        if ($this->type === 'user' && $currentOECount === '0') {
+            $this->setUsersDefaultOutboundAccount($defaultOwner, $this->id);
         }
 
         return $results;

--- a/public/legacy/modules/OutboundEmailAccounts/controller.php
+++ b/public/legacy/modules/OutboundEmailAccounts/controller.php
@@ -164,7 +164,13 @@ class OutboundEmailAccountsController extends SugarController
         $outbound_id = empty($_REQUEST['record']) ? "" : $_REQUEST['record'];
         $oe = BeanFactory::newBean('OutboundEmailAccounts');
 
-        $ownerId = $this->bean->created_by ?? '';
+        $ownerId = '';
+        if (($this->bean->type ?? '') === 'user') {
+            $ownerId = $this->bean->user_id ?? '';
+        }
+        if (empty($ownerId)) {
+            $ownerId = $this->bean->created_by ?? '';
+        }
         if (empty($ownerId)) {
             $ownerId = $current_user->id;
         }

--- a/public/legacy/modules/OutboundEmailAccounts/metadata/detailviewdefs.php
+++ b/public/legacy/modules/OutboundEmailAccounts/metadata/detailviewdefs.php
@@ -8,7 +8,7 @@ $viewdefs ['OutboundEmailAccounts'] = [
                     'DELETE',
                     [
                         'customCode' => '
-                            {if $fields.type.value === "user" && $fields.created_by.value == $current_user_id}
+                            {if $fields.type.value === "user" && ($fields.user_id.value == $current_user_id || $is_admin)}
                             <input title="{$MOD.LBL_SET_AS_DEFAULT_BUTTON}"
                                    type="button"
                                    class="button"


### PR DESCRIPTION
## Summary

This PR fixes default outbound email account behavior for regular users in compose flows.

It resolves a mismatch where personal outbound accounts owned by users were not reliably usable as defaults when the account had been created by an admin, and where compose could stay empty even when the user had exactly one personal outbound account.

## Scope

Limited to:

- `core/modules/EmailMarketing/Service/Fields/InitOutboundEmailDefault.php`
- `public/legacy/modules/OutboundEmailAccounts/OutboundEmailAccounts.php`
- `public/legacy/modules/OutboundEmailAccounts/controller.php`
- `public/legacy/modules/OutboundEmailAccounts/metadata/detailviewdefs.php`

## Root Causes

1. Default outbound resolution in the Suite8 init process relied only on `Emails.defaultOEAccount` preference.
   If unset, compose `From` could remain unselected even when the user had exactly one personal outbound account.

2. Personal outbound default assignment on save used `$current_user` instead of the actual account owner (`user_id`).
   When admins created personal accounts for others, default could be assigned to admin instead of owner.

3. "Set as default" owner checks used `created_by` semantics rather than personal-account owner (`user_id`).
   Users could be blocked from setting default on their own personal account if the creator was different.

## What Changed

### 1) Fallback for single personal outbound account (`InitOutboundEmailDefault.php`)

- Keep existing preference-first behavior.
- If `defaultOEAccount` is empty, fetch current user's outbound accounts.
- If there is exactly one valid personal outbound account (`type=user` with non-empty from address), use it as the init default.

### 2) Save-path default assignment uses owner (`OutboundEmailAccounts.php`)

- Resolve default target user from `user_id` for personal accounts.
- Count existing personal outbound accounts for that owner.
- If this is owner's first personal account, assign default to owner (not creator/admin session user).
- Guard default assignment to `type=user` accounts only.

### 3) SetDefault action resolves owner by `user_id` first (`controller.php`)

- In `action_SetDefault`, owner resolution now prefers `user_id` when account type is `user`.
- Falls back to `created_by`, then current user if needed.
- Preserves existing permission check semantics (`owner == current_user || admin`).

### 4) Detail view button visibility updated (`detailviewdefs.php`)

- "Set as default" button visibility now checks personal account owner (`user_id`) instead of `created_by`.
- Admin retains access to the button.

## Behavior After Fix

- Compose `From` can auto-populate for users with exactly one personal outbound account even if no default preference exists yet.
- Admin-created personal outbound accounts correctly set default for the owner on first-account creation.
- Users can set default on their own personal outbound accounts regardless of who originally created the record.

## Non-Goals

- No outbound transport/protocol changes.
- No IMAP Sent append changes.
- No schema migrations.
- No frontend framework refactor.

## Validation

- `php -l core/modules/EmailMarketing/Service/Fields/InitOutboundEmailDefault.php`
- `php -l public/legacy/modules/OutboundEmailAccounts/OutboundEmailAccounts.php`
- `php -l public/legacy/modules/OutboundEmailAccounts/controller.php`
- `php -l public/legacy/modules/OutboundEmailAccounts/metadata/detailviewdefs.php`
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [ ] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->