### PR TITLE
Use DB-formatted datetime values in campaign queue manager

### DIFF
--- a/core/modules/Campaigns/Service/Email/Queue/DefaultEmailQueueManager.php
+++ b/core/modules/Campaigns/Service/Email/Queue/DefaultEmailQueueManager.php
@@ -131,7 +131,7 @@ class DefaultEmailQueueManager implements EmailQueueManagerInterface
 
         $timedate = $this->dateTimeHandler->getDateTime();
         $now = $timedate->nowDb();
-        $str = $timedate->fromString("-1 day")?->asDb();
+        $queueDate = $this->relativeDbDateTime($timedate, '-1 day', $now);
 
         $queryBuilder = $this->preparedStatementHandler->createQueryBuilder();
         $queryBuilder->select('*')
@@ -155,7 +155,7 @@ class DefaultEmailQueueManager implements EmailQueueManagerInterface
                      ->setMaxResults($batchSize)
                      ->setParameter('mkt_id', $marketingId)
                      ->setParameter('now', $now)
-                     ->setParameter('queue_date', $str);
+                     ->setParameter('queue_date', $queueDate);
 
         try {
             $results = $queryBuilder->fetchAllAssociative();
@@ -217,7 +217,7 @@ class DefaultEmailQueueManager implements EmailQueueManagerInterface
             ->set('in_queue_date', ':in_queue_date')
             ->where('id = :id')
             ->setParameter('in_queue', '1')
-            ->setParameter('in_queue_date', (new \DateTime())->format('Y-m-d H:i:s'))
+            ->setParameter('in_queue_date', $timedate->nowDb())
             ->setParameter('id', $id);
 
         try {
@@ -225,5 +225,12 @@ class DefaultEmailQueueManager implements EmailQueueManagerInterface
         } catch (Exception $e) {
             $this->logger->error('DefaultEmailQueueManager::updateSendAttempts | Failed to update send attempts for ID: ' . $id . ' | Error: ' . $e->getMessage(), ['trace' => $e->getTrace()]);
         }
+    }
+
+    protected function relativeDbDateTime(\TimeDate $timedate, string $modifier, string $fallback): string
+    {
+        $date = $timedate->fromString($modifier);
+
+        return $date?->asDb() ?? $fallback;
     }
 }


### PR DESCRIPTION
## Problem
In campaign email queue processing, datetime values were built using mixed strategies inside `DefaultEmailQueueManager`:
- queue cutoff (`-1 day`) had no fallback if date parsing fails
- `in_queue_date` update used raw `new \DateTime()->format(...)` instead of SuiteCRM `TimeDate` DB formatting

In strict MySQL environments, queue datetime comparisons are sensitive to value format consistency in DBAL parameters and can fail with `Incorrect DATETIME value` when non-DB-formatted values leak into the query path.

## Root Cause
`DefaultEmailQueueManager` did not consistently normalize all queue-related datetime parameters through SuiteCRM's `TimeDate` DB format helpers.

## Changes
- Replaced ad-hoc queue cutoff variable with `relativeDbDateTime(...)` helper:
  - always returns DB datetime string
  - falls back to current DB datetime if relative parsing returns null
- Replaced `in_queue_date` update parameter from `(new \DateTime())->format('Y-m-d H:i:s')` to `$timedate->nowDb()`
- Kept queue logic unchanged (`older than 1 day` behavior remains)

## Files
- `core/modules/Campaigns/Service/Email/Queue/DefaultEmailQueueManager.php`

## Validation
- `php -l core/modules/Campaigns/Service/Email/Queue/DefaultEmailQueueManager.php`
- DEV evidence from scheduler/queue path for strict MySQL datetime error baseline:
  - `SQLSTATE[HY000]: General error: 1525 Incorrect DATETIME value`
- Post-fix smoke in DEV showed no new `Incorrect DATETIME value` entries during scheduler runs.

## Risk / Scope
- Small, isolated change in one queue manager class.
- No schema changes.
- No config/sql_mode changes.
