### PR TITLE
Fix #862 -Legacy campaign send to prefer Email Marketing content over template

### DIFF
--- a/public/legacy/modules/EmailMan/EmailMan.php
+++ b/public/legacy/modules/EmailMan/EmailMan.php
@@ -1005,6 +1005,17 @@ class EmailMan extends SugarBean
                 $this->current_emailtemplate->body_html = from_html($this->current_emailtemplate->body_html);
                 $this->current_emailtemplate->body = from_html($this->current_emailtemplate->body);
 
+                // Prefer Email Marketing content over template content when provided.
+                $emailMarketingSubject = trim((string)($this->current_emailmarketing->subject ?? ''));
+                $emailMarketingBody = (string)($this->current_emailmarketing->body ?? '');
+                if ($emailMarketingSubject !== '') {
+                    $this->current_emailtemplate->subject = from_html($emailMarketingSubject);
+                }
+                if (trim($emailMarketingBody) !== '') {
+                    $this->current_emailtemplate->body_html = from_html($emailMarketingBody);
+                    $this->current_emailtemplate->body = from_html(strip_tags($emailMarketingBody));
+                }
+
                 $q = "SELECT * FROM notes WHERE parent_id = '" . $this->current_emailtemplate->id . "' AND deleted = 0";
                 $r = $this->db->query($q);
 


### PR DESCRIPTION
## Problem
Legacy campaign delivery (`function::runMassEmailCampaign` -> `EmailMan`) can send subject/body from the linked Email Template even when Email Marketing content has been edited in UI.

## Root Cause
In legacy `EmailMan::sendEmail()`, `current_emailtemplate` content was always used after template retrieval. `email_marketing.subject/body` did not override template values.

## Changes
- File: `public/legacy/modules/EmailMan/EmailMan.php`
- After template content unescape, prefer Email Marketing content when present:
  - override subject with `email_marketing.subject` if non-empty
  - override body_html/body with `email_marketing.body` if non-empty
- Kept fallback behavior: if Email Marketing fields are empty, template content is still used.

## Validation
- `php -l public/legacy/modules/EmailMan/EmailMan.php`
- DEV evidence with test campaign data:
  - legacy path reached (`Run Nightly Mass Email Campaigns`)
  - generated campaign email record used Email Marketing subject/body marker (`DO YOU SEND THIS OR THE TEMPLATE?`)
  - template marker (`Issue 848 test`) not present in generated body

## Scope / Risk
- Small, isolated change in one legacy file.
- No schema changes.
- No config changes.
