### PR TITLE
Add optional Microsoft Graph outbound skeleton transport (PR1)

### DIFF
--- a/public/legacy/include/OutboundEmail/Transport/ConfigTokenProvider.php
+++ b/public/legacy/include/OutboundEmail/Transport/ConfigTokenProvider.php
@@ -1,0 +1,145 @@
+<?php
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+class ConfigTokenProvider implements TokenProviderInterface
+{
+    public function getAccessToken(MailTransportAccountConfig $config): string
+    {
+        $explicitToken = trim((string)($config->accessToken ?? ''));
+        if ($explicitToken !== '') {
+            return $explicitToken;
+        }
+
+        $configuredToken = trim((string)$this->getFirstConfigValue([
+            'graph_mailer_access_token',
+            'graph_mail_access_token',
+        ], ''));
+        if ($configuredToken !== '') {
+            return $configuredToken;
+        }
+
+        $connectionId = trim((string)($config->oauthConnectionId ?? ''));
+        if ($connectionId !== '') {
+            $token = $this->extractTokenFromOAuthConnection($connectionId);
+            if ($token !== '') {
+                return $token;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * PR1 scope: best-effort read from existing OAuth connection.
+     * Refresh/rotation logic is intentionally deferred to PR2.
+     */
+    private function extractTokenFromOAuthConnection(string $connectionId): string
+    {
+        try {
+            if (!class_exists('BeanFactory')) {
+                require_once 'data/BeanFactory.php';
+            }
+            /** @var object|null $connection */
+            $connection = BeanFactory::getBean('ExternalOAuthConnection', $connectionId);
+            if (empty($connection)) {
+                return '';
+            }
+
+            $raw = trim((string)($connection->access_token ?? ''));
+            return $this->extractAccessToken($raw);
+        } catch (\Throwable $e) {
+            $GLOBALS['log']->warn('ConfigTokenProvider: failed to read OAuth access token: ' . $e->getMessage());
+        }
+
+        return '';
+    }
+
+    private function getFirstConfigValue(array $keys, $default = null)
+    {
+        $config = $GLOBALS['sugar_config'] ?? [];
+        foreach ($keys as $key) {
+            if (array_key_exists($key, $config)) {
+                return $config[$key];
+            }
+        }
+
+        return $default;
+    }
+
+    private function extractAccessToken(string $value): string
+    {
+        $value = trim(str_replace(["\r", "\n"], '', $value));
+        if ($value === '') {
+            return '';
+        }
+
+        // Plain JWT or opaque token.
+        if (strpos($value, '.') !== false || preg_match('/^[A-Za-z0-9_\-~\+\/=]{20,}$/', $value)) {
+            if (substr_count($value, '.') === 2 || strpos($value, '{') === false) {
+                return $value;
+            }
+        }
+
+        // JSON object
+        if ($value[0] === '{' || $value[0] === '[') {
+            $json = json_decode($value, true);
+            if (is_array($json)) {
+                foreach (['access_token', 'token', 'AccessToken', 'accessToken'] as $key) {
+                    if (!empty($json[$key])) {
+                        return trim((string)$json[$key]);
+                    }
+                }
+            }
+        }
+
+        // Serialized payload
+        if (preg_match('/^(a|s):\d+:/', $value)) {
+            $decoded = @unserialize($value);
+            if (is_array($decoded)) {
+                foreach (['access_token', 'token', 'AccessToken', 'accessToken'] as $key) {
+                    if (!empty($decoded[$key])) {
+                        return trim((string)$decoded[$key]);
+                    }
+                }
+            } elseif (is_string($decoded) && $decoded !== '') {
+                return trim($decoded);
+            }
+        }
+
+        // base64/base64url wrapper
+        $decoded = $this->tryBase64Decode($value);
+        if ($decoded !== '') {
+            return $this->extractAccessToken($decoded);
+        }
+
+        return '';
+    }
+
+    private function tryBase64Decode(string $value): string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            return '';
+        }
+
+        $normalized = strtr($value, '-_', '+/');
+        $remainder = strlen($normalized) % 4;
+        if ($remainder > 0) {
+            $normalized .= str_repeat('=', 4 - $remainder);
+        }
+
+        $decoded = base64_decode($normalized, true);
+        if (!is_string($decoded) || $decoded === '') {
+            return '';
+        }
+
+        if (preg_match('/[^\x09\x0A\x0D\x20-\x7E]/', $decoded)) {
+            return '';
+        }
+
+        return trim($decoded);
+    }
+}

--- a/public/legacy/include/OutboundEmail/Transport/GraphHttpClient.php
+++ b/public/legacy/include/OutboundEmail/Transport/GraphHttpClient.php
@@ -1,0 +1,119 @@
+<?php
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+class GraphHttpClient
+{
+    /**
+     * @param string $url
+     * @param array<int, string> $headers
+     * @param array<string, mixed> $payload
+     * @return array{ok: bool, status: int, headers: array<string, string>, body: string, error: string}
+     */
+    public function postJson(string $url, array $headers, array $payload): array
+    {
+        if (!function_exists('curl_init')) {
+            return [
+                'ok' => false,
+                'status' => 0,
+                'headers' => [],
+                'body' => '',
+                'error' => 'cURL extension is not available',
+            ];
+        }
+
+        $ch = curl_init($url);
+        if ($ch === false) {
+            return [
+                'ok' => false,
+                'status' => 0,
+                'headers' => [],
+                'body' => '',
+                'error' => 'Unable to initialize cURL',
+            ];
+        }
+
+        $body = json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if ($body === false) {
+            return [
+                'ok' => false,
+                'status' => 0,
+                'headers' => [],
+                'body' => '',
+                'error' => 'JSON encode failed: ' . json_last_error_msg(),
+            ];
+        }
+
+        curl_setopt_array($ch, [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => $body,
+            CURLOPT_HTTPHEADER => $headers,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HEADER => true,
+            CURLOPT_CONNECTTIMEOUT => 10,
+            CURLOPT_TIMEOUT => 30,
+            CURLOPT_NOSIGNAL => 1,
+            CURLOPT_SSL_VERIFYPEER => true,
+            CURLOPT_SSL_VERIFYHOST => 2,
+        ]);
+
+        $response = curl_exec($ch);
+        $status = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $headerSize = (int)curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+        $error = curl_error($ch);
+        curl_close($ch);
+
+        if ($response === false) {
+            return [
+                'ok' => false,
+                'status' => $status,
+                'headers' => [],
+                'body' => '',
+                'error' => $error !== '' ? $error : 'Unknown cURL error',
+            ];
+        }
+
+        $rawHeaders = (string)substr($response, 0, $headerSize);
+        $rawBody = (string)substr($response, $headerSize);
+
+        return [
+            'ok' => true,
+            'status' => $status,
+            'headers' => $this->parseHeaders($rawHeaders),
+            'body' => $rawBody,
+            'error' => '',
+        ];
+    }
+
+    /**
+     * @param string $rawHeaders
+     * @return array<string, string>
+     */
+    private function parseHeaders(string $rawHeaders): array
+    {
+        $headers = [];
+        $headerBlocks = preg_split("/\r\n\r\n|\n\n/", trim($rawHeaders)) ?: [];
+        $lastBlock = end($headerBlocks);
+        if (!is_string($lastBlock)) {
+            return $headers;
+        }
+
+        $lines = preg_split("/\r\n|\n/", $lastBlock) ?: [];
+        foreach ($lines as $line) {
+            $line = trim($line);
+            if ($line === '' || strpos($line, ':') === false) {
+                continue;
+            }
+            [$name, $value] = explode(':', $line, 2);
+            $name = strtolower(trim($name));
+            $value = trim($value);
+            if ($name !== '') {
+                $headers[$name] = $value;
+            }
+        }
+
+        return $headers;
+    }
+}

--- a/public/legacy/include/OutboundEmail/Transport/GraphMailerAdapter.php
+++ b/public/legacy/include/OutboundEmail/Transport/GraphMailerAdapter.php
@@ -1,0 +1,140 @@
+<?php
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+class GraphMailerAdapter implements MailerInterface
+{
+    /** @var TokenProviderInterface */
+    private $tokenProvider;
+    /** @var GraphHttpClient */
+    private $httpClient;
+
+    public function __construct(TokenProviderInterface $tokenProvider, ?GraphHttpClient $httpClient = null)
+    {
+        $this->tokenProvider = $tokenProvider;
+        $this->httpClient = $httpClient ?: new GraphHttpClient();
+    }
+
+    public function send(MailTransportMessage $message, MailTransportAccountConfig $config): MailTransportSendResult
+    {
+        if (!empty($message->attachments)) {
+            return MailTransportSendResult::failure(
+                'graph_skeleton_attachments_not_supported',
+                'Graph skeleton adapter supports sendMail without attachments only.'
+            );
+        }
+
+        $accessToken = trim($this->tokenProvider->getAccessToken($config));
+        if ($accessToken === '') {
+            return MailTransportSendResult::failure(
+                'graph_missing_access_token',
+                'Graph access token is missing. Configure token provider before enabling Graph skeleton send.'
+            );
+        }
+
+        $payload = [
+            'message' => [
+                'subject' => (string)$message->subject,
+                'body' => [
+                    'contentType' => $message->htmlBody !== '' ? 'HTML' : 'Text',
+                    'content' => $message->htmlBody !== '' ? (string)$message->htmlBody : (string)$message->textBody,
+                ],
+                'toRecipients' => $this->mapRecipients((array)$message->to),
+            ],
+            'saveToSentItems' => true,
+        ];
+
+        if (!empty($message->cc)) {
+            $payload['message']['ccRecipients'] = $this->mapRecipients((array)$message->cc);
+        }
+        if (!empty($message->bcc)) {
+            $payload['message']['bccRecipients'] = $this->mapRecipients((array)$message->bcc);
+        }
+        if (!empty($config->replyToAddress)) {
+            $payload['message']['replyTo'] = [[
+                'emailAddress' => [
+                    'address' => (string)$config->replyToAddress,
+                    'name' => (string)$config->replyToName,
+                ],
+            ]];
+        }
+        if (!empty($message->fromName) || !empty($message->from)) {
+            $payload['message']['from'] = [
+                'emailAddress' => [
+                    'address' => (string)$message->from,
+                    'name' => (string)$message->fromName,
+                ],
+            ];
+        }
+
+        $endpoint = $this->resolveEndpoint((string)($config->senderMailbox ?? ''), (string)($message->from ?? ''));
+        $url = 'https://graph.microsoft.com' . $endpoint;
+
+        $headers = [
+            'Authorization: Bearer ' . $accessToken,
+            'Content-Type: application/json',
+            'Accept: application/json',
+        ];
+
+        $response = $this->httpClient->postJson($url, $headers, $payload);
+        if (empty($response['ok'])) {
+            return MailTransportSendResult::failure(
+                'graph_http_client_error',
+                'Graph HTTP client error: ' . (string)($response['error'] ?? 'unknown')
+            );
+        }
+
+        $status = (int)($response['status'] ?? 0);
+        if ($status !== 202 && $status !== 200) {
+            $bodyPreview = substr((string)($response['body'] ?? ''), 0, 500);
+
+            return MailTransportSendResult::failure(
+                'graph_http_' . $status,
+                'Graph sendMail failed with HTTP ' . $status . '. Response: ' . $bodyPreview
+            );
+        }
+
+        $headerMap = (array)($response['headers'] ?? []);
+        $requestId = (string)($headerMap['request-id'] ?? ($headerMap['client-request-id'] ?? ''));
+
+        return MailTransportSendResult::success($requestId);
+    }
+
+    private function resolveEndpoint(string $senderMailbox, string $messageFrom): string
+    {
+        $senderMailbox = trim($senderMailbox);
+        if ($senderMailbox === '') {
+            $senderMailbox = trim($messageFrom);
+        }
+
+        if ($senderMailbox !== '' && strpos($senderMailbox, '@') !== false) {
+            return '/v1.0/users/' . rawurlencode($senderMailbox) . '/sendMail';
+        }
+
+        return '/v1.0/me/sendMail';
+    }
+
+    /**
+     * @param string[] $emails
+     * @return array<int, array<string, array<string, string>>>
+     */
+    private function mapRecipients(array $emails): array
+    {
+        $out = [];
+        foreach ($emails as $email) {
+            $email = trim((string)$email);
+            if ($email === '') {
+                continue;
+            }
+            $out[] = [
+                'emailAddress' => [
+                    'address' => $email,
+                ],
+            ];
+        }
+
+        return $out;
+    }
+}

--- a/public/legacy/include/OutboundEmail/Transport/MailTransportAccountConfig.php
+++ b/public/legacy/include/OutboundEmail/Transport/MailTransportAccountConfig.php
@@ -1,0 +1,21 @@
+<?php
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+class MailTransportAccountConfig
+{
+    /** @var string */
+    public $transport = 'smtp';
+    /** @var string */
+    public $oauthConnectionId = '';
+    /** @var string */
+    public $senderMailbox = '';
+    /** @var string */
+    public $accessToken = '';
+    /** @var string */
+    public $replyToAddress = '';
+    /** @var string */
+    public $replyToName = '';
+}

--- a/public/legacy/include/OutboundEmail/Transport/MailTransportMessage.php
+++ b/public/legacy/include/OutboundEmail/Transport/MailTransportMessage.php
@@ -1,0 +1,27 @@
+<?php
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+class MailTransportMessage
+{
+    /** @var string */
+    public $from = '';
+    /** @var string */
+    public $fromName = '';
+    /** @var string[] */
+    public $to = [];
+    /** @var string[] */
+    public $cc = [];
+    /** @var string[] */
+    public $bcc = [];
+    /** @var string */
+    public $subject = '';
+    /** @var string */
+    public $htmlBody = '';
+    /** @var string */
+    public $textBody = '';
+    /** @var array<int, array<string, mixed>> */
+    public $attachments = [];
+}

--- a/public/legacy/include/OutboundEmail/Transport/MailTransportSendResult.php
+++ b/public/legacy/include/OutboundEmail/Transport/MailTransportSendResult.php
@@ -1,0 +1,36 @@
+<?php
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+class MailTransportSendResult
+{
+    /** @var bool */
+    public $success = false;
+    /** @var string */
+    public $errorCode = '';
+    /** @var string */
+    public $errorMessage = '';
+    /** @var string */
+    public $providerRequestId = '';
+
+    public static function success(string $providerRequestId = ''): self
+    {
+        $result = new self();
+        $result->success = true;
+        $result->providerRequestId = $providerRequestId;
+
+        return $result;
+    }
+
+    public static function failure(string $errorCode, string $errorMessage): self
+    {
+        $result = new self();
+        $result->success = false;
+        $result->errorCode = $errorCode;
+        $result->errorMessage = $errorMessage;
+
+        return $result;
+    }
+}

--- a/public/legacy/include/OutboundEmail/Transport/MailerInterface.php
+++ b/public/legacy/include/OutboundEmail/Transport/MailerInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+interface MailerInterface
+{
+    public function send(
+        MailTransportMessage $message,
+        MailTransportAccountConfig $config
+    ): MailTransportSendResult;
+}

--- a/public/legacy/include/OutboundEmail/Transport/TokenProviderInterface.php
+++ b/public/legacy/include/OutboundEmail/Transport/TokenProviderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+interface TokenProviderInterface
+{
+    public function getAccessToken(MailTransportAccountConfig $config): string;
+}

--- a/public/legacy/include/SugarPHPMailer.php
+++ b/public/legacy/include/SugarPHPMailer.php
@@ -493,6 +493,242 @@ eoq;
     }
 
     /**
+     * Resolve outbound transport configuration with backward-compatible fallbacks.
+     */
+    private function resolveOutboundTransportConfig(): array
+    {
+        $mailTransport = $this->normalizeTransportValue((string)($this->oe->mail_transport ?? ''));
+        $authType = strtolower(trim((string)($this->oe->auth_type ?? '')));
+        $oauthConnectionId = trim((string)($this->oe->external_oauth_connection_id ?? ''));
+        $host = trim((string)($this->Host ?? ($this->oe->mail_smtpserver ?? '')));
+
+        $graphEnabled = (bool)$this->getFirstConfigValue([
+            'graph_mailer_enabled',
+            'graph_mail_enabled',
+        ], false);
+
+        $matchHost = trim((string)$this->getFirstConfigValue([
+            'graph_mailer_match_host',
+            'graph_mail_match_host',
+        ], 'smtp.office365.com'));
+
+        $senderMailbox = trim((string)($this->oe->graph_sender_mailbox ?? ''));
+        if ($senderMailbox === '') {
+            $senderMailbox = trim((string)($this->oe->from_addr ?? ''));
+        }
+        if ($senderMailbox === '') {
+            $senderMailbox = trim((string)($this->oe->smtp_from_addr ?? ''));
+        }
+        if ($senderMailbox === '') {
+            $senderMailbox = trim((string)($this->From ?? ''));
+        }
+
+        $transport = 'smtp';
+        $selector = 'default_smtp';
+
+        if ($mailTransport === 'graph') {
+            $transport = 'graph';
+            $selector = 'mail_transport';
+        } elseif (
+            $graphEnabled
+            && $authType === 'oauth'
+            && $oauthConnectionId !== ''
+            && $this->hostMatches($host, $matchHost)
+        ) {
+            $transport = 'graph';
+            $selector = 'legacy_host_oauth';
+        }
+
+        return [
+            'transport' => $transport,
+            'selector' => $selector,
+            'host' => $host,
+            'match_host' => $matchHost,
+            'graph_enabled' => $graphEnabled,
+            'auth_type' => $authType,
+            'oauth_connection_id' => $oauthConnectionId,
+            'sender_mailbox' => $senderMailbox,
+            'from_addr' => trim((string)($this->oe->smtp_from_addr ?? ($this->From ?? ''))),
+            'from_name' => trim((string)($this->oe->smtp_from_name ?? ($this->FromName ?? ''))),
+            'reply_to_addr' => trim((string)($this->oe->reply_to_addr ?? '')),
+            'reply_to_name' => trim((string)($this->oe->reply_to_name ?? '')),
+        ];
+    }
+
+    private function shouldUseGraphTransport(array $transportConfig): bool
+    {
+        return ($transportConfig['transport'] ?? 'smtp') === 'graph';
+    }
+
+    private function logTransportDecision(array $transportConfig): void
+    {
+        $GLOBALS['log']->debug(
+            'SugarPHPMailer::send transport config: transport=' . ($transportConfig['transport'] ?? 'smtp') .
+            ', selector=' . ($transportConfig['selector'] ?? 'unknown') .
+            ', host=' . ($transportConfig['host'] ?? '') .
+            ', auth=' . ($transportConfig['auth_type'] ?? '') .
+            ', graph_enabled=' . (!empty($transportConfig['graph_enabled']) ? 'true' : 'false') .
+            ', has_oauth_connection=' . (!empty($transportConfig['oauth_connection_id']) ? 'true' : 'false') .
+            ', has_sender_mailbox=' . (!empty($transportConfig['sender_mailbox']) ? 'true' : 'false')
+        );
+    }
+
+    private function normalizeTransportValue(string $value): string
+    {
+        $value = strtolower(trim($value));
+        if ($value === 'graph' || $value === 'smtp') {
+            return $value;
+        }
+
+        return '';
+    }
+
+    private function hostMatches(string $host, string $matchHost): bool
+    {
+        if ($matchHost === '') {
+            return true;
+        }
+
+        if ($host === '') {
+            return false;
+        }
+
+        return stripos($host, $matchHost) !== false;
+    }
+
+    private function getFirstConfigValue(array $keys, $default = null)
+    {
+        $config = $GLOBALS['sugar_config'] ?? [];
+        foreach ($keys as $key) {
+            if (array_key_exists($key, $config)) {
+                return $config[$key];
+            }
+        }
+
+        return $default;
+    }
+
+    private function isGraphSkeletonEnabled(): bool
+    {
+        $value = $this->getFirstConfigValue([
+            'graph_mailer_skeleton_enabled',
+            'graph_mail_skeleton_enabled',
+        ], false);
+
+        if (is_string($value)) {
+            return in_array(strtolower(trim($value)), ['1', 'true', 'yes', 'on'], true);
+        }
+
+        return !empty($value);
+    }
+
+    /**
+     * @param array<int, mixed> $addresses
+     * @return array<int, string>
+     */
+    private function normalizeAddressList(array $addresses): array
+    {
+        $list = [];
+        foreach ($addresses as $address) {
+            $candidate = is_array($address) ? (string)($address[0] ?? '') : (string)$address;
+            if (preg_match('/<([^>]+)>/', $candidate, $match)) {
+                $candidate = (string)$match[1];
+            }
+            $candidate = trim($candidate);
+            if ($candidate !== '') {
+                $list[] = $candidate;
+            }
+        }
+
+        return $list;
+    }
+
+    private function buildMailTransportMessage(): MailTransportMessage
+    {
+        $message = new MailTransportMessage();
+        $message->from = trim((string)($this->From ?? ''));
+        $message->fromName = trim((string)($this->FromName ?? ''));
+        $message->to = $this->normalizeAddressList((array)$this->getToAddresses());
+        $message->cc = $this->normalizeAddressList((array)$this->getCcAddresses());
+        $message->bcc = $this->normalizeAddressList((array)$this->getBccAddresses());
+        $message->subject = (string)($this->Subject ?? '');
+        $message->htmlBody = (string)($this->Body ?? '');
+        $message->textBody = (string)($this->AltBody ?? '');
+
+        foreach ((array)$this->attachment as $attachment) {
+            $path = (string)($attachment[0] ?? '');
+            $name = (string)($attachment[2] ?? ($attachment[1] ?? ''));
+            $message->attachments[] = [
+                'path' => $path,
+                'name' => $name,
+                'is_file' => $path !== '' && file_exists($path),
+            ];
+        }
+
+        return $message;
+    }
+
+    private function buildGraphAccountConfig(array $transportConfig): MailTransportAccountConfig
+    {
+        $config = new MailTransportAccountConfig();
+        $config->transport = 'graph';
+        $config->oauthConnectionId = trim((string)($transportConfig['oauth_connection_id'] ?? ''));
+        if ($config->oauthConnectionId === '') {
+            $config->oauthConnectionId = trim((string)$this->getFirstConfigValue([
+                'graph_mailer_oauth_connection_id',
+                'graph_mail_oauth_connection_id',
+            ], ''));
+        }
+
+        $config->senderMailbox = trim((string)($transportConfig['sender_mailbox'] ?? ''));
+        $config->replyToAddress = trim((string)($transportConfig['reply_to_addr'] ?? ''));
+        $config->replyToName = trim((string)($transportConfig['reply_to_name'] ?? ''));
+        $config->accessToken = trim((string)$this->getFirstConfigValue([
+            'graph_mailer_access_token',
+            'graph_mail_access_token',
+        ], ''));
+
+        return $config;
+    }
+
+    private function trySendViaGraphSkeleton(array $transportConfig): bool
+    {
+        if (!$this->isGraphSkeletonEnabled()) {
+            $GLOBALS['log']->debug('SugarPHPMailer::send Graph skeleton feature flag disabled');
+            return false;
+        }
+
+        require_once 'include/OutboundEmail/Transport/MailerInterface.php';
+        require_once 'include/OutboundEmail/Transport/TokenProviderInterface.php';
+        require_once 'include/OutboundEmail/Transport/MailTransportMessage.php';
+        require_once 'include/OutboundEmail/Transport/MailTransportAccountConfig.php';
+        require_once 'include/OutboundEmail/Transport/MailTransportSendResult.php';
+        require_once 'include/OutboundEmail/Transport/GraphHttpClient.php';
+        require_once 'include/OutboundEmail/Transport/ConfigTokenProvider.php';
+        require_once 'include/OutboundEmail/Transport/GraphMailerAdapter.php';
+
+        $message = $this->buildMailTransportMessage();
+        $accountConfig = $this->buildGraphAccountConfig($transportConfig);
+        $adapter = new GraphMailerAdapter(new ConfigTokenProvider());
+        $result = $adapter->send($message, $accountConfig);
+
+        if ($result->success) {
+            $GLOBALS['log']->info(
+                'SugarPHPMailer::send Graph skeleton sendMail succeeded' .
+                ($result->providerRequestId !== '' ? ' request_id=' . $result->providerRequestId : '')
+            );
+            return true;
+        }
+
+        $GLOBALS['log']->warn(
+            'SugarPHPMailer::send Graph skeleton send failed, falling back to SMTP. code=' .
+            (string)$result->errorCode . ' message=' . (string)$result->errorMessage
+        );
+
+        return false;
+    }
+
+    /**
      * overloads PHPMailer::Send() to allow for better logging and debugging SMTP issues
      *
      * @return bool
@@ -512,6 +748,15 @@ eoq;
 
         $this->fullSmtpLog='';
         $phpMailerExceptionMsg='';
+
+        $transportConfig = $this->resolveOutboundTransportConfig();
+        $this->logTransportDecision($transportConfig);
+
+        if ($this->shouldUseGraphTransport($transportConfig)) {
+            if ($this->trySendViaGraphSkeleton($transportConfig)) {
+                return true;
+            }
+        }
 
         try {
             $saveExceptionsState = $this->exceptions;


### PR DESCRIPTION
# Add Optional Microsoft Graph Outbound Skeleton Transport (PR1)

## Problem
- SuiteCRM currently relies on SMTP transport paths for outbound email.
- In Microsoft 365 environments (especially shared mailbox send-as scenarios), SMTP OAuth can be fragile and difficult to operate under modern security policies.
- There is no transport abstraction for introducing Graph incrementally while preserving existing SMTP behavior.

## Root Cause
- Outbound sending is tightly coupled to SMTP execution paths.
- There is no dedicated Graph adapter contract that can be enabled safely behind a feature flag.

## Changes
- Add a transport skeleton under `include/OutboundEmail/Transport`:
  - `MailerInterface`
  - `TokenProviderInterface`
  - `MailTransportMessage`
  - `MailTransportAccountConfig`
  - `MailTransportSendResult`
  - `GraphHttpClient`
  - `ConfigTokenProvider` (PR1 best-effort token read only; no refresh/rotation logic yet)
  - `GraphMailerAdapter` (basic `sendMail` only)
- Extend `SugarPHPMailer` with deterministic transport resolution:
  - explicit `mail_transport=graph` support (when present)
  - backward-compatible host-based fallback (`smtp.office365.com` + OAuth + connection)
- Add a feature-flagged Graph execution path in `SugarPHPMailer::send()`:
  - flag keys: `graph_mailer_skeleton_enabled` / `graph_mail_skeleton_enabled`
  - when enabled and Graph is selected, run Graph adapter first
  - on failure, log and fall back to existing SMTP path
- Keep SMTP as default behavior and unchanged fallback.

## Out of Scope (Follow-up PRs)
- Delegated OAuth refresh/rotation hardening
- explicit Send As diagnostics
- throttling/retry/idempotency policy
- large attachment upload sessions
- UI transport selector and Graph-specific validation

## How to Test
1. Static checks
   - `php -l public/legacy/include/SugarPHPMailer.php`
   - `php -l public/legacy/include/OutboundEmail/Transport/*.php`
2. Baseline regression
   - keep Graph skeleton feature flag disabled
   - send outbound test email via existing SMTP account
   - verify behavior unchanged
3. Graph skeleton path
   - set `graph_mailer_skeleton_enabled=true`
   - select Graph transport via account config (or legacy fallback host+OAuth)
   - provide access token via config key (`graph_mailer_access_token`) for PR1 validation
   - run outbound send and verify request goes to Graph `sendMail`
   - if Graph fails, verify SMTP fallback and warning log

## Notes
- This PR is the first incremental step of a broader Graph rollout.
- It introduces optional Graph transport safely without changing default SMTP behavior.
