### PR TITLE
Fix EmailMarketing popup fatal by adding missing popupdefs metadata

### DIFF
--- a/public/legacy/modules/EmailMarketing/metadata/popupdefs.php
+++ b/public/legacy/modules/EmailMarketing/metadata/popupdefs.php
@@ -1,0 +1,68 @@
+<?php
+if (!defined('sugarEntry') || !sugarEntry) {
+    die('Not A Valid Entry Point');
+}
+
+$popupMeta = array(
+    'moduleMain' => 'EmailMarketing',
+    'varName' => 'EMAILMARKETING',
+    'orderBy' => 'email_marketing.name',
+    'whereClauses' => array(
+        'name' => 'email_marketing.name',
+        'status' => 'email_marketing.status',
+        'type' => 'email_marketing.type',
+    ),
+    'searchInputs' => array(
+        1 => 'name',
+        2 => 'status',
+        3 => 'type',
+    ),
+    'searchdefs' => array(
+        'name' => array(
+            'name' => 'name',
+            'label' => 'LBL_NAME',
+            'width' => '20%',
+        ),
+        'status' => array(
+            'name' => 'status',
+            'type' => 'enum',
+            'label' => 'LBL_STATUS',
+            'options' => 'email_marketing_status_dom',
+            'width' => '10%',
+        ),
+        'type' => array(
+            'name' => 'type',
+            'type' => 'enum',
+            'label' => 'LBL_MARKETING_TYPE',
+            'options' => 'email_marketing_type_dom',
+            'width' => '10%',
+        ),
+    ),
+    'listviewdefs' => array(
+        'NAME' => array(
+            'width' => '35%',
+            'label' => 'LBL_LIST_NAME',
+            'link' => true,
+            'default' => true,
+            'name' => 'name',
+        ),
+        'DATE_START' => array(
+            'width' => '20%',
+            'label' => 'LBL_DATE_START',
+            'default' => true,
+            'name' => 'date_start',
+        ),
+        'STATUS' => array(
+            'width' => '15%',
+            'label' => 'LBL_LIST_STATUS',
+            'default' => true,
+            'name' => 'status',
+        ),
+        'TYPE' => array(
+            'width' => '15%',
+            'label' => 'LBL_MARKETING_TYPE',
+            'default' => true,
+            'name' => 'type',
+        ),
+    ),
+);


### PR DESCRIPTION
## Summary
This PR fixes a fatal error when opening the legacy popup selector for `EmailMarketing` records.

The popup controller (`Popup_picker`) expects `modules/EmailMarketing/metadata/popupdefs.php`, but the file is missing in the `EmailMarketing` module. As a result, any `relate` field that opens `module=EmailMarketing&action=Popup` fails with a blank popup and a PHP fatal error.

This change adds the missing `popupdefs.php` metadata file with search and list definitions for `EmailMarketing`.

## Root Cause
`include/Popups/Popup_picker.php` loads module popup metadata via:
- `modules/<Module>/metadata/popupdefs.php`

For `EmailMarketing`, that file did not exist.

## Fix
Added:
- `public/legacy/modules/EmailMarketing/metadata/popupdefs.php`

The metadata includes:
- `whereClauses` for `name`, `status`, `type`
- `searchdefs` for `name`, `status`, `type`
- `listviewdefs` for `name`, `date_start`, `status`, `type`

## Impact
Fixes blank/failing popup windows for `EmailMarketing` selection in legacy views (for example report filters based on Campaign Log marketing message fields).

## Manual Test
1. Open a legacy view that uses an `EmailMarketing` relate selector popup.
2. Click the popup (arrow) button.
3. Confirm popup loads with records instead of crashing.

## Backward Compatibility
- No database changes.
- No API changes.
- Legacy metadata-only fix.
