### PR TITLE
Fix #797 - Default editor type to TinyMCE and validate preferences

### DIFF
--- a/public/legacy/modules/Users/User.php
+++ b/public/legacy/modules/Users/User.php
@@ -2598,8 +2598,12 @@ EOQ;
 
     public function getEditorType()
     {
+        global $app_list_strings;
+
+        $validEditorTypes = array_keys($app_list_strings['dom_editor_type'] ?? []);
+
         $editorType = $this->getPreference('editor_type');
-        if (!$editorType) {
+        if (!$editorType || !in_array($editorType, $validEditorTypes, true)) {
             $editorType = 'tinymce';
             $this->setPreference('editor_type', $editorType);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

Fixes #797 — Saving a user profile without explicitly selecting an editor type stores an invalid `'html'` value for the `editor_type` preference. Later, when creating an email template, `SuiteEditorConnector` fails with `Exception in Controller: unknown editor type: html` because it only recognizes `'none'`, `'tinymce'`, and `'mozaik'`.

The root cause was a copy-paste error: `'html'` is a valid value for `email_editor_option` but not for `editor_type`.

This fix adds validation in `getEditorType()` to check the stored preference against the allowed values from `dom_editor_type`. If the value is invalid or missing, it falls back to `'tinymce'`, which also self-heals accounts that already have `'html'` persisted.

```diff
     public function getEditorType()
     {
+        global $app_list_strings;
+
+        $validEditorTypes = array_keys($app_list_strings['dom_editor_type'] ?? []);
+
         $editorType = $this->getPreference('editor_type');
-        if (!$editorType) {
+        if (!$editorType || !in_array($editorType, $validEditorTypes, true)) {
             $editorType = 'tinymce';
             $this->setPreference('editor_type', $editorType);
         }
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Users who save their profile without explicitly selecting an editor type get an invalid preference stored. This makes email template creation impossible until the preference is manually corrected. The validation ensures any invalid or missing editor type preference is automatically corrected to `'tinymce'`.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Log in as admin user
2. Navigate to Profile settings
3. Save profile WITHOUT selecting an editor type
4. Navigate to Email Templates module and click "Create Email Template"
5. Verify the template editor loads successfully (TinyMCE) with no fatal error
6. Test with each valid editor type (TinyMCE, Direct HTML) — verify each loads correctly
7. Check logs for absence of "unknown editor type" exceptions

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->
