### PR TITLE
Fix #100 Opportunity Role Editor + subpanel edit to open relationship editor when supported

### DIFF
--- a/core/app/core/src/lib/containers/subpanel/adapters/line-actions.adapter.ts
+++ b/core/app/core/src/lib/containers/subpanel/adapters/line-actions.adapter.ts
@@ -146,6 +146,8 @@ export class SubpanelLineActionsAdapter extends BaseActionsAdapter<SubpanelLineA
             })
         }
 
+        const relationshipEdit = this.getRelationshipEditPayload(action, context, module);
+
         return {
             action: actionName,
             module: moduleName,
@@ -157,7 +159,79 @@ export class SubpanelLineActionsAdapter extends BaseActionsAdapter<SubpanelLineA
                 recordModule: module,
                 relateModule: this.store.metadata.module,
                 relateRecordId: (context && context.record && context.record.id) || '',
+                ...(relationshipEdit ? {relationshipEdit} : {}),
             }
         } as AsyncActionInput;
+    }
+
+    /**
+     * Build relationship edit payload for special subpanel edit widgets.
+     */
+    protected getRelationshipEditPayload(
+        action: Action,
+        context: ActionContext,
+        module: string
+    ): {[key: string]: any} | null {
+        const relationshipEdit = action?.params?.relationshipEdit ?? null;
+        if (!relationshipEdit || relationshipEdit.enabled !== true) {
+            return null;
+        }
+
+        const relationshipAction = relationshipEdit.action ?? '';
+        const relationshipModule = relationshipEdit.module ?? module;
+        if (!relationshipAction || !relationshipModule) {
+            return null;
+        }
+
+        return {
+            enabled: true,
+            module: relationshipModule,
+            action: relationshipAction,
+            recordId: this.resolveRelationshipRecordId(context, relationshipEdit.recordField ?? ''),
+            fallbackToRecordEdit: relationshipEdit.fallbackToRecordEdit !== false
+        };
+    }
+
+    /**
+     * Resolve relation row id from subpanel record attributes.
+     */
+    protected resolveRelationshipRecordId(context: ActionContext, recordField: string): string {
+        const attributes = context?.record?.attributes ?? null;
+        if (!attributes || !recordField) {
+            return '';
+        }
+
+        const value = this.getRecordAttribute(attributes, recordField);
+        if (value === undefined || value === null) {
+            return '';
+        }
+
+        if (typeof value === 'object') {
+            if (value && value.id) {
+                return `${value.id}`;
+            }
+
+            return '';
+        }
+
+        return `${value}`;
+    }
+
+    /**
+     * Read attribute with a case-insensitive key match.
+     */
+    protected getRecordAttribute(attributes: {[key: string]: any}, key: string): any {
+        if (!Object.prototype.hasOwnProperty.call(attributes, key)) {
+            const normalizedKey = key.toLowerCase();
+            const matchedKey = Object.keys(attributes).find(attributeKey => attributeKey.toLowerCase() === normalizedKey);
+
+            if (!matchedKey) {
+                return null;
+            }
+
+            return attributes[matchedKey];
+        }
+
+        return attributes[key];
     }
 }

--- a/core/backend/Process/Service/RecordActions/EditAction.php
+++ b/core/backend/Process/Service/RecordActions/EditAction.php
@@ -43,12 +43,19 @@ class EditAction implements ProcessHandlerInterface
     private $moduleNameMapper;
 
     /**
+     * @var string
+     */
+    private $legacyDir;
+
+    /**
      * EditAction constructor.
      * @param ModuleNameMapperInterface $moduleNameMapper
+     * @param string $legacyDir
      */
-    public function __construct(ModuleNameMapperInterface $moduleNameMapper)
+    public function __construct(ModuleNameMapperInterface $moduleNameMapper, string $legacyDir)
     {
         $this->moduleNameMapper = $moduleNameMapper;
+        $this->legacyDir = $legacyDir;
     }
 
     /**
@@ -144,20 +151,32 @@ class EditAction implements ProcessHandlerInterface
     public function run(Process $process)
     {
         $options = $process->getOptions();
+        $relationshipEdit = $options['payload']['relationshipEdit'] ?? [];
 
-        //parent module
+        $responseData = $this->buildRelationshipEditResponseData($options, $relationshipEdit);
+        if (empty($responseData)) {
+            $responseData = $this->buildRecordEditResponseData($options);
+        }
+
+        $process->setStatus('success');
+        $process->setMessages([]);
+        $process->setData($responseData);
+    }
+
+    /**
+     * Build default subpanel record edit response.
+     */
+    protected function buildRecordEditResponseData(array $options): array
+    {
         $baseModule = $this->moduleNameMapper->toLegacy($options['payload']['baseModule']);
         $baseRecordId = $options['payload']['baseRecordId'];
-
-        //linked(subpanel) module
         $linkedModule = $options["payload"]["recordModule"];
         $linkedRecordId = $options['id'];
-        $linkedAction = 'edit';
 
-        $responseData = [
+        return [
             'handler' => 'redirect',
             'params' => [
-                'route' => $linkedModule . '/' . $linkedAction . '/' . $linkedRecordId,
+                'route' => $linkedModule . '/edit/' . $linkedRecordId,
                 'queryParams' => [
                     'action_module' => $linkedModule,
                     'return_action' => 'DetailView',
@@ -166,9 +185,75 @@ class EditAction implements ProcessHandlerInterface
                 ]
             ]
         ];
+    }
 
-        $process->setStatus('success');
-        $process->setMessages([]);
-        $process->setData($responseData);
+    /**
+     * Build relationship-edit redirect response, if supported by legacy action.
+     */
+    protected function buildRelationshipEditResponseData(array $options, array $relationshipEdit): array
+    {
+        if (($relationshipEdit['enabled'] ?? false) !== true) {
+            return [];
+        }
+
+        $relationshipModule = $relationshipEdit['module'] ?? '';
+        $relationshipAction = $relationshipEdit['action'] ?? '';
+        $relationshipRecordId = $relationshipEdit['recordId'] ?? '';
+
+        if ($relationshipModule === '' || $relationshipAction === '' || $relationshipRecordId === '') {
+            return [];
+        }
+
+        if (!$this->isLegacyActionImplemented($relationshipModule, $relationshipAction)) {
+            return [];
+        }
+
+        $baseModule = $this->moduleNameMapper->toLegacy($options['payload']['baseModule']);
+        $baseRecordId = $options['payload']['baseRecordId'];
+
+        return [
+            'handler' => 'redirect',
+            'params' => [
+                'route' => $relationshipModule . '/' . $relationshipAction . '/' . $relationshipRecordId,
+                'queryParams' => [
+                    'action_module' => $relationshipModule,
+                    'return_action' => 'DetailView',
+                    'return_module' => $baseModule,
+                    'return_id' => $baseRecordId
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * Check if target legacy action has a backing php entry file.
+     */
+    protected function isLegacyActionImplemented(string $module, string $action): bool
+    {
+        $legacyModule = $this->moduleNameMapper->toLegacy($module);
+        if (!$this->isSafeLegacyIdentifier($legacyModule) || !$this->isSafeLegacyIdentifier($action)) {
+            return false;
+        }
+
+        $paths = [
+            $this->legacyDir . '/custom/modules/' . $legacyModule . '/' . $action . '.php',
+            $this->legacyDir . '/modules/' . $legacyModule . '/' . $action . '.php',
+        ];
+
+        foreach ($paths as $path) {
+            if (is_readable($path)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Validate module/action values used to build legacy file paths.
+     */
+    protected function isSafeLegacyIdentifier(string $value): bool
+    {
+        return $value !== '' && preg_match('/^[A-Za-z0-9_]+$/', $value) === 1;
     }
 }

--- a/core/backend/ViewDefinitions/LegacyHandler/SubPanelDefinitionHandler.php
+++ b/core/backend/ViewDefinitions/LegacyHandler/SubPanelDefinitionHandler.php
@@ -594,15 +594,189 @@ class SubPanelDefinitionHandler extends LegacyHandler implements SubPanelDefinit
                 ) {
                     $lineAction = $subpanelLineActions[$list_field['name']];
                     $moduleName = $this->moduleNameMapper->toFrontEnd($subpanelModule);
-                    $lineActions[] = $this->subpanelLineActionDefinitionProvider->getLineAction(
+                    $lineActionDefinition = $this->subpanelLineActionDefinitionProvider->getLineAction(
                         $moduleName,
                         $lineAction
+                    );
+
+                    if (empty($lineActionDefinition)) {
+                        continue;
+                    }
+
+                    $lineActions[] = $this->mapRelationshipEditLineAction(
+                        $lineActionDefinition,
+                        $list_field,
+                        $subpanelModule
                     );
                 }
             }
         }
 
         return $lineActions;
+    }
+
+    /**
+     * Map relation-edit widget data to line action params.
+     */
+    protected function mapRelationshipEditLineAction(
+        array $lineAction,
+        array $listField,
+        string $subpanelModule
+    ): array {
+        if (($lineAction['key'] ?? '') !== 'edit') {
+            return $lineAction;
+        }
+
+        $relationshipEditConfig = $this->buildRelationshipEditConfig($listField, $subpanelModule);
+        if (empty($relationshipEditConfig)) {
+            return $lineAction;
+        }
+
+        $lineAction['params'] = $lineAction['params'] ?? [];
+        $lineAction['params']['relationshipEdit'] = $relationshipEditConfig;
+
+        return $lineAction;
+    }
+
+    /**
+     * Build relationship edit action configuration for special edit widgets.
+     */
+    protected function buildRelationshipEditConfig(array $listField, string $subpanelModule): array
+    {
+        $widgetClass = $listField['widget_class'] ?? '';
+        if (!$this->isRelationshipEditWidgetClass($widgetClass)) {
+            return [];
+        }
+
+        $widgetConfig = $this->extractRelationshipEditFromWidgetClass($widgetClass);
+        $relationshipAction = $widgetConfig['action'] ?? '';
+        if ($relationshipAction === '') {
+            return [];
+        }
+
+        $relationshipModule = $widgetConfig['module'] ?? '';
+        if ($relationshipModule === '') {
+            $relationshipModule = $listField['module'] ?? $subpanelModule;
+        }
+
+        $recordField = $widgetConfig['recordField'] ?? '';
+        if ($recordField === '' && !empty($listField['role_id'])) {
+            $recordField = strtoupper((string)$listField['role_id']);
+        }
+
+        $moduleName = $this->moduleNameMapper->toFrontEnd($relationshipModule);
+        if ($moduleName === '') {
+            $moduleName = $relationshipModule;
+        }
+
+        return [
+            'enabled' => true,
+            'module' => $moduleName,
+            'action' => $relationshipAction,
+            'recordField' => $recordField,
+            'fallbackToRecordEdit' => true,
+        ];
+    }
+
+    /**
+     * Determine if widget represents a relationship edit action.
+     */
+    protected function isRelationshipEditWidgetClass(string $widgetClass): bool
+    {
+        if ($widgetClass === '' || $widgetClass === 'SubPanelEditButton') {
+            return false;
+        }
+
+        if (!str_starts_with($widgetClass, 'SubPanelEdit')) {
+            return false;
+        }
+
+        return str_ends_with($widgetClass, 'Button');
+    }
+
+    /**
+     * Extract relationship edit metadata from the legacy widget class.
+     */
+    protected function extractRelationshipEditFromWidgetClass(string $widgetClass): array
+    {
+        $widgetFilePath = $this->getWidgetClassFilePath($widgetClass);
+        if ($widgetFilePath === '') {
+            return [];
+        }
+
+        $widgetSource = file_get_contents($widgetFilePath);
+        if ($widgetSource === false || $widgetSource === '') {
+            return [];
+        }
+
+        return [
+            'action' => $this->findActionNameInWidgetClass($widgetSource),
+            'module' => $this->findModuleNameInWidgetClass($widgetSource),
+            'recordField' => $this->findRecordFieldInWidgetClass($widgetSource),
+        ];
+    }
+
+    /**
+     * Get widget file path from class name.
+     */
+    protected function getWidgetClassFilePath(string $widgetClass): string
+    {
+        $paths = [
+            $this->legacyDir . '/custom/include/generic/SugarWidgets/SugarWidget' . $widgetClass . '.php',
+            $this->legacyDir . '/include/generic/SugarWidgets/SugarWidget' . $widgetClass . '.php',
+        ];
+
+        foreach ($paths as $path) {
+            if (is_readable($path)) {
+                return $path;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Find relationship action name from widget source.
+     */
+    protected function findActionNameInWidgetClass(string $widgetSource): string
+    {
+        $patterns = [
+            "/&action='\\s*\\.\\s*'([A-Za-z0-9_]+)'/i",
+            '/&action="\\s*\\.\\s*"([A-Za-z0-9_]+)"/i',
+            '/[?&]action=([A-Za-z0-9_]+)/i',
+        ];
+
+        foreach ($patterns as $pattern) {
+            if (preg_match($pattern, $widgetSource, $matches) === 1) {
+                return $matches[1] ?? '';
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Find relationship module name from widget source.
+     */
+    protected function findModuleNameInWidgetClass(string $widgetSource): string
+    {
+        if (preg_match('/index\\.php\\?module=([A-Za-z0-9_]+)/i', $widgetSource, $matches) === 1) {
+            return $matches[1] ?? '';
+        }
+
+        return '';
+    }
+
+    /**
+     * Find relation-record field name used in widget source.
+     */
+    protected function findRecordFieldInWidgetClass(string $widgetSource): string
+    {
+        if (preg_match('/\\$layout_def\\[[\'"]fields[\'"]\\]\\[[\'"]([A-Za-z0-9_]+)[\'"]\\]/i', $widgetSource, $matches) === 1) {
+            return $matches[1] ?? '';
+        }
+
+        return '';
     }
 
     /**

--- a/tests/unit/core/src/Service/RecordActions/EditActionTest.php
+++ b/tests/unit/core/src/Service/RecordActions/EditActionTest.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * SuiteCRM is a customer relationship management program developed by SalesAgility Ltd.
+ * Copyright (C) 2021 SalesAgility Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License version 3 as published by the
+ * Free Software Foundation with the addition of the following permission added
+ * to Section 15 as permitted in Section 7(a): FOR ANY PART OF THE COVERED WORK
+ * IN WHICH THE COPYRIGHT IS OWNED BY SALESAGILITY, SALESAGILITY DISCLAIMS THE
+ * WARRANTY OF NON INFRINGEMENT OF THIRD PARTY RIGHTS.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *
+ * In accordance with Section 7(b) of the GNU Affero General Public License
+ * version 3, these Appropriate Legal Notices must retain the display of the
+ * "Supercharged by SuiteCRM" logo. If the display of the logos is not reasonably
+ * feasible for technical reasons, the Appropriate Legal Notices must display
+ * the words "Supercharged by SuiteCRM".
+ */
+
+
+namespace App\Tests\unit\core\src\Service\RecordActions;
+
+use App\Module\Service\ModuleNameMapperInterface;
+use App\Process\Entity\Process;
+use App\Process\Service\RecordActions\EditAction;
+use App\Tests\UnitTester;
+use Codeception\Test\Unit;
+
+/**
+ * Class EditActionTest
+ * @package App\Tests\unit\core\src\Service\RecordActions
+ */
+class EditActionTest extends Unit
+{
+    /**
+     * @var UnitTester
+     */
+    protected $tester;
+
+    /**
+     * @var EditAction
+     */
+    protected $service;
+
+    protected function _before(): void
+    {
+        /** @var ModuleNameMapperInterface $moduleNameMapper */
+        $moduleNameMapper = $this->makeEmpty(
+            ModuleNameMapperInterface::class,
+            [
+                'toLegacy' => function (string $module): string {
+                    $map = [
+                        'contacts' => 'Contacts',
+                        'opportunities' => 'Opportunities',
+                    ];
+
+                    return $map[$module] ?? $module;
+                }
+            ]
+        );
+
+        $this->service = new EditAction(
+            $moduleNameMapper,
+            $this->tester->getLegacyDir()
+        );
+    }
+
+    /**
+     * Regression: relation edit must redirect to legacy relation action when it exists.
+     */
+    public function testRelationshipEditRedirectWhenLegacyActionExists(): void
+    {
+        $process = new Process();
+        $process->setType('record-edit');
+        $process->setOptions([
+            'action' => 'record-edit',
+            'id' => '19b870a2-8d0b-4f4b-9116-67b5e501590f',
+            'module' => 'contacts',
+            'payload' => [
+                'baseModule' => 'opportunities',
+                'baseRecordId' => 'b641b285-1f5e-47a3-8a8d-0508aa20c2b1',
+                'linkField' => 'contacts',
+                'recordModule' => 'contacts',
+                'relationshipEdit' => [
+                    'enabled' => true,
+                    'module' => 'contacts',
+                    'action' => 'ContactOpportunityRelationshipEdit',
+                    'recordId' => '90d6129c-2a2b-4160-804e-f16ebe230443',
+                    'fallbackToRecordEdit' => true
+                ]
+            ]
+        ]);
+
+        $this->service->run($process);
+
+        static::assertSame([
+            'handler' => 'redirect',
+            'params' => [
+                'route' => 'contacts/ContactOpportunityRelationshipEdit/90d6129c-2a2b-4160-804e-f16ebe230443',
+                'queryParams' => [
+                    'action_module' => 'contacts',
+                    'return_action' => 'DetailView',
+                    'return_module' => 'Opportunities',
+                    'return_id' => 'b641b285-1f5e-47a3-8a8d-0508aa20c2b1'
+                ]
+            ]
+        ], $process->getData());
+
+        static::assertSame('success', $process->getStatus());
+        static::assertSame([], $process->getMessages());
+    }
+
+    /**
+     * Regression: fallback must go to related record edit when relation action is not implemented.
+     */
+    public function testRelationshipEditFallbackToRecordEditWhenLegacyActionMissing(): void
+    {
+        $process = new Process();
+        $process->setType('record-edit');
+        $process->setOptions([
+            'action' => 'record-edit',
+            'id' => '19b870a2-8d0b-4f4b-9116-67b5e501590f',
+            'module' => 'contacts',
+            'payload' => [
+                'baseModule' => 'opportunities',
+                'baseRecordId' => 'b641b285-1f5e-47a3-8a8d-0508aa20c2b1',
+                'linkField' => 'contacts',
+                'recordModule' => 'contacts',
+                'relationshipEdit' => [
+                    'enabled' => true,
+                    'module' => 'contacts',
+                    'action' => 'ActionThatDoesNotExist',
+                    'recordId' => '90d6129c-2a2b-4160-804e-f16ebe230443',
+                    'fallbackToRecordEdit' => true
+                ]
+            ]
+        ]);
+
+        $this->service->run($process);
+
+        static::assertSame([
+            'handler' => 'redirect',
+            'params' => [
+                'route' => 'contacts/edit/19b870a2-8d0b-4f4b-9116-67b5e501590f',
+                'queryParams' => [
+                    'action_module' => 'contacts',
+                    'return_action' => 'DetailView',
+                    'return_module' => 'Opportunities',
+                    'return_id' => 'b641b285-1f5e-47a3-8a8d-0508aa20c2b1'
+                ]
+            ]
+        ], $process->getData());
+
+        static::assertSame('success', $process->getStatus());
+        static::assertSame([], $process->getMessages());
+    }
+}


### PR DESCRIPTION
## Summary
- add relationship edit metadata to subpanel edit line actions for legacy relation-edit widgets
- send relationship edit payload from subpanel line-actions adapter
- update record-edit backend action to redirect to relationship edit route when available
- keep fallback to standard related record edit when relationship action is not implemented
- add unit regression tests for relationship redirect and fallback

## Files
- core/app/core/src/lib/containers/subpanel/adapters/line-actions.adapter.ts
- core/backend/ViewDefinitions/LegacyHandler/SubPanelDefinitionHandler.php
- core/backend/Process/Service/RecordActions/EditAction.php
- tests/unit/core/src/Service/RecordActions/EditActionTest.php

## Verification
- php -l tests/unit/core/src/Service/RecordActions/EditActionTest.php
- php -l core/backend/Process/Service/RecordActions/EditAction.php
- codecept command:
  php -d auto_prepend_file=/tmp/aspectmock_kernel_stub.php vendor/bin/codecept run unit core/src/Service/RecordActions/EditActionTest.php
- result: OK (2 tests, 6 assertions)

## Issue
- Fixes #100
- Context: https://github.com/SuiteCRM/SuiteCRM-Core/issues/100