### PR TITLE
Follow-up #100: modern Opportunity-Contact role editor (depends on #884)

### DIFF
--- a/core/app/core/src/lib/containers/subpanel/adapters/line-actions.adapter.ts
+++ b/core/app/core/src/lib/containers/subpanel/adapters/line-actions.adapter.ts
@@ -107,6 +107,11 @@ export class SubpanelLineActionsAdapter extends BaseActionsAdapter<SubpanelLineA
         return 'list' as ViewMode;
     }
 
+    runAction(action: Action, context: ActionContext = null): void {
+        this.applyRelationshipEditFieldModalDefaults(action, context);
+        super.runAction(action, context);
+    }
+
     protected getModuleName(context?: ActionContext): string {
         return this.store.metadata.module;
     }
@@ -183,13 +188,117 @@ export class SubpanelLineActionsAdapter extends BaseActionsAdapter<SubpanelLineA
             return null;
         }
 
+        const relationshipValues = this.getRelationshipEditFieldValues(action);
+
         return {
             enabled: true,
             module: relationshipModule,
             action: relationshipAction,
             recordId: this.resolveRelationshipRecordId(context, relationshipEdit.recordField ?? ''),
-            fallbackToRecordEdit: relationshipEdit.fallbackToRecordEdit !== false
+            fallbackToRecordEdit: relationshipEdit.fallbackToRecordEdit !== false,
+            ...(relationshipEdit.modern ? {modern: relationshipEdit.modern} : {}),
+            ...(relationshipValues ? {values: relationshipValues} : {}),
         };
+    }
+
+    /**
+     * Apply current row role value as default for modern relationship edit field modal.
+     */
+    protected applyRelationshipEditFieldModalDefaults(action: Action, context: ActionContext): void {
+        const relationshipEdit = action?.params?.relationshipEdit ?? null;
+        const fieldModal = action?.params?.fieldModal ?? null;
+        const modernConfig = relationshipEdit?.modern ?? null;
+
+        if (!relationshipEdit || !fieldModal || !modernConfig || modernConfig.enabled !== true) {
+            return;
+        }
+
+        const roleField = modernConfig.roleField ?? '';
+        const valueField = modernConfig.valueField ?? roleField;
+        if (!roleField || !valueField) {
+            return;
+        }
+
+        const attributes = context?.record?.attributes ?? null;
+        if (!attributes) {
+            return;
+        }
+
+        const rawValue = this.getRecordAttribute(attributes, valueField);
+        if (rawValue === undefined || rawValue === null) {
+            return;
+        }
+
+        const defaultValue = this.normalizeRelationshipEditValue(rawValue);
+        fieldModal.fields = (fieldModal.fields ?? []).map((field: {[key: string]: any}) => {
+            if ((field?.name ?? '') !== roleField) {
+                return field;
+            }
+
+            const fieldDefinition = field?.fieldDefinition ?? {};
+            return {
+                ...field,
+                defaultValue,
+                fieldDefinition: {
+                    ...fieldDefinition,
+                    default: defaultValue,
+                    defaultValue
+                }
+            };
+        });
+    }
+
+    /**
+     * Extract field-modal values to relation edit payload values map.
+     */
+    protected getRelationshipEditFieldValues(action: Action): {[key: string]: string} | null {
+        const fields = action?.params?.fields ?? null;
+        if (!fields || typeof fields !== 'object') {
+            return null;
+        }
+
+        const values: {[key: string]: string} = {};
+        Object.keys(fields).forEach(fieldName => {
+            const fieldValue = fields[fieldName]?.value;
+            if (fieldValue === undefined || fieldValue === null) {
+                return;
+            }
+
+            values[fieldName] = this.normalizeRelationshipEditValue(fieldValue);
+        });
+
+        if (!Object.keys(values).length) {
+            return null;
+        }
+
+        return values;
+    }
+
+    /**
+     * Normalize modal field values into string payload values.
+     */
+    protected normalizeRelationshipEditValue(value: any): string {
+        if (value === undefined || value === null) {
+            return '';
+        }
+
+        if (typeof value === 'object') {
+            if (value?.value !== undefined && value?.value !== null) {
+                return `${value.value}`;
+            }
+
+            if (value?.name !== undefined && value?.name !== null) {
+                return `${value.name}`;
+            }
+
+            if (value?.id !== undefined && value?.id !== null) {
+                return `${value.id}`;
+            }
+
+            return '';
+        }
+
+        return `${value}`;
     }
 
     /**

--- a/core/backend/Process/Service/RecordActions/EditAction.php
+++ b/core/backend/Process/Service/RecordActions/EditAction.php
@@ -31,6 +31,7 @@ use ApiPlatform\Exception\InvalidArgumentException;
 use App\Module\Service\ModuleNameMapperInterface;
 use App\Process\Entity\Process;
 use App\Process\Service\ProcessHandlerInterface;
+use Throwable;
 
 class EditAction implements ProcessHandlerInterface
 {
@@ -153,6 +154,14 @@ class EditAction implements ProcessHandlerInterface
         $options = $process->getOptions();
         $relationshipEdit = $options['payload']['relationshipEdit'] ?? [];
 
+        $modernResponse = $this->buildModernRelationshipEditResponseData($relationshipEdit);
+        if (($modernResponse['handled'] ?? false) === true) {
+            $process->setStatus($modernResponse['status'] ?? 'success');
+            $process->setMessages($modernResponse['messages'] ?? []);
+            $process->setData($modernResponse['data'] ?? null);
+            return;
+        }
+
         $responseData = $this->buildRelationshipEditResponseData($options, $relationshipEdit);
         if (empty($responseData)) {
             $responseData = $this->buildRecordEditResponseData($options);
@@ -161,6 +170,60 @@ class EditAction implements ProcessHandlerInterface
         $process->setStatus('success');
         $process->setMessages([]);
         $process->setData($responseData);
+    }
+
+    /**
+     * Build modern relationship-edit save response.
+     */
+    protected function buildModernRelationshipEditResponseData(array $relationshipEdit): array
+    {
+        if (($relationshipEdit['enabled'] ?? false) !== true) {
+            return ['handled' => false];
+        }
+
+        $modernConfig = $relationshipEdit['modern'] ?? [];
+        if (($modernConfig['enabled'] ?? false) !== true) {
+            return ['handled' => false];
+        }
+
+        if (!$this->isOpportunityContactRelationshipEdit($relationshipEdit)) {
+            return ['handled' => false];
+        }
+
+        $values = $relationshipEdit['values'] ?? [];
+        $roleField = $modernConfig['roleField'] ?? 'opportunity_role';
+        if ($roleField === '' || !array_key_exists($roleField, $values)) {
+            return ['handled' => false];
+        }
+
+        $relationshipRecordId = (string)($relationshipEdit['recordId'] ?? '');
+        if ($relationshipRecordId === '') {
+            return [
+                'handled' => true,
+                'status' => 'error',
+                'messages' => ['LBL_ACTION_ERROR'],
+                'data' => null
+            ];
+        }
+
+        $contactRole = (string)$values[$roleField];
+        if (!$this->saveOpportunityContactRole($relationshipRecordId, $contactRole)) {
+            return [
+                'handled' => true,
+                'status' => 'error',
+                'messages' => ['LBL_ACTION_ERROR'],
+                'data' => null
+            ];
+        }
+
+        return [
+            'handled' => true,
+            'status' => 'success',
+            'messages' => [],
+            'data' => [
+                'reload' => true
+            ]
+        ];
     }
 
     /**
@@ -255,5 +318,48 @@ class EditAction implements ProcessHandlerInterface
     protected function isSafeLegacyIdentifier(string $value): bool
     {
         return $value !== '' && preg_match('/^[A-Za-z0-9_]+$/', $value) === 1;
+    }
+
+    /**
+     * Check if payload targets Contacts->Opportunities relationship role edit.
+     */
+    protected function isOpportunityContactRelationshipEdit(array $relationshipEdit): bool
+    {
+        $relationshipModule = strtolower((string)($relationshipEdit['module'] ?? ''));
+        $relationshipAction = (string)($relationshipEdit['action'] ?? '');
+
+        return $relationshipModule === 'contacts'
+            && $relationshipAction === 'ContactOpportunityRelationshipEdit';
+    }
+
+    /**
+     * Save contact role on opportunities_contacts relationship row.
+     */
+    protected function saveOpportunityContactRole(string $relationshipRecordId, string $contactRole): bool
+    {
+        $relationshipClassFile = $this->legacyDir . '/modules/Contacts/ContactOpportunityRelationship.php';
+        if (!is_readable($relationshipClassFile)) {
+            return false;
+        }
+
+        require_once $relationshipClassFile;
+        if (!class_exists('ContactOpportunityRelationship')) {
+            return false;
+        }
+
+        try {
+            $relationship = new \ContactOpportunityRelationship();
+            $relationship->retrieve($relationshipRecordId);
+            if (empty($relationship->id)) {
+                return false;
+            }
+
+            $relationship->contact_role = $contactRole;
+            $relationship->save();
+        } catch (Throwable $exception) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/core/backend/ViewDefinitions/LegacyHandler/SubPanelDefinitionHandler.php
+++ b/core/backend/ViewDefinitions/LegacyHandler/SubPanelDefinitionHandler.php
@@ -634,6 +634,10 @@ class SubPanelDefinitionHandler extends LegacyHandler implements SubPanelDefinit
 
         $lineAction['params'] = $lineAction['params'] ?? [];
         $lineAction['params']['relationshipEdit'] = $relationshipEditConfig;
+        $fieldModalConfig = $this->buildRelationshipEditFieldModalConfig($relationshipEditConfig);
+        if (!empty($fieldModalConfig)) {
+            $lineAction['params']['fieldModal'] = $fieldModalConfig;
+        }
 
         return $lineAction;
     }
@@ -669,12 +673,87 @@ class SubPanelDefinitionHandler extends LegacyHandler implements SubPanelDefinit
             $moduleName = $relationshipModule;
         }
 
-        return [
+        $config = [
             'enabled' => true,
             'module' => $moduleName,
             'action' => $relationshipAction,
             'recordField' => $recordField,
             'fallbackToRecordEdit' => true,
+        ];
+
+        $modernConfig = $this->buildModernRelationshipEditConfig($moduleName, $relationshipAction);
+        if (!empty($modernConfig)) {
+            $config['modern'] = $modernConfig;
+        }
+
+        return $config;
+    }
+
+    /**
+     * Build modern-UI relation editor config for known relationship edit actions.
+     */
+    protected function buildModernRelationshipEditConfig(string $moduleName, string $relationshipAction): array
+    {
+        if (strtolower($moduleName) !== 'contacts' || $relationshipAction !== 'ContactOpportunityRelationshipEdit') {
+            return [];
+        }
+
+        return [
+            'enabled' => true,
+            'roleField' => 'opportunity_role',
+            'valueField' => 'opportunity_role',
+            'options' => 'opportunity_relationship_type_dom',
+            'labelKey' => 'LBL_CONTACT_ROLE',
+            'titleKey' => 'LBL_EDIT_RECORD',
+            'actionLabelKey' => 'LBL_SAVE',
+        ];
+    }
+
+    /**
+     * Build field-modal config for relationship edit actions with modern support.
+     */
+    protected function buildRelationshipEditFieldModalConfig(array $relationshipEditConfig): array
+    {
+        $modernConfig = $relationshipEditConfig['modern'] ?? [];
+        if (($modernConfig['enabled'] ?? false) !== true) {
+            return [];
+        }
+
+        $roleField = $modernConfig['roleField'] ?? '';
+        if ($roleField === '') {
+            return [];
+        }
+
+        $labelKey = $modernConfig['labelKey'] ?? 'LBL_CONTACT_ROLE';
+        $options = $modernConfig['options'] ?? 'opportunity_relationship_type_dom';
+
+        return [
+            'module' => $relationshipEditConfig['module'] ?? '',
+            'titleKey' => $modernConfig['titleKey'] ?? 'LBL_EDIT_RECORD',
+            'actionLabelKey' => $modernConfig['actionLabelKey'] ?? 'LBL_SAVE',
+            'fieldGridOptions' => [
+                'maxColumns' => 1,
+                'sizeMap' => [
+                    'handset' => 1,
+                    'tablet' => 1,
+                    'web' => 1,
+                    'wide' => 1,
+                ],
+            ],
+            'fields' => [
+                [
+                    'name' => $roleField,
+                    'type' => 'enum',
+                    'label' => $labelKey,
+                    'fieldDefinition' => [
+                        'name' => $roleField,
+                        'type' => 'enum',
+                        'vname' => $labelKey,
+                        'options' => $options,
+                        'required' => true,
+                    ],
+                ],
+            ],
         ];
     }
 

--- a/tests/unit/core/src/Service/RecordActions/EditActionTest.php
+++ b/tests/unit/core/src/Service/RecordActions/EditActionTest.php
@@ -50,10 +50,15 @@ class EditActionTest extends Unit
      */
     protected $service;
 
+    /**
+     * @var ModuleNameMapperInterface
+     */
+    protected $moduleNameMapper;
+
     protected function _before(): void
     {
         /** @var ModuleNameMapperInterface $moduleNameMapper */
-        $moduleNameMapper = $this->makeEmpty(
+        $this->moduleNameMapper = $this->makeEmpty(
             ModuleNameMapperInterface::class,
             [
                 'toLegacy' => function (string $module): string {
@@ -68,7 +73,7 @@ class EditActionTest extends Unit
         );
 
         $this->service = new EditAction(
-            $moduleNameMapper,
+            $this->moduleNameMapper,
             $this->tester->getLegacyDir()
         );
     }
@@ -161,5 +166,100 @@ class EditActionTest extends Unit
 
         static::assertSame('success', $process->getStatus());
         static::assertSame([], $process->getMessages());
+    }
+
+    /**
+     * Regression: modern relation edit should save relationship role and reload subpanel.
+     */
+    public function testModernRelationshipEditSavesRoleAndReloads(): void
+    {
+        $service = new class($this->moduleNameMapper, $this->tester->getLegacyDir()) extends EditAction {
+            protected function saveOpportunityContactRole(string $relationshipRecordId, string $contactRole): bool
+            {
+                return $relationshipRecordId === '90d6129c-2a2b-4160-804e-f16ebe230443'
+                    && $contactRole === 'Primary Decision Maker';
+            }
+        };
+
+        $process = new Process();
+        $process->setType('record-edit');
+        $process->setOptions([
+            'action' => 'record-edit',
+            'id' => '19b870a2-8d0b-4f4b-9116-67b5e501590f',
+            'module' => 'contacts',
+            'payload' => [
+                'baseModule' => 'opportunities',
+                'baseRecordId' => 'b641b285-1f5e-47a3-8a8d-0508aa20c2b1',
+                'linkField' => 'contacts',
+                'recordModule' => 'contacts',
+                'relationshipEdit' => [
+                    'enabled' => true,
+                    'module' => 'contacts',
+                    'action' => 'ContactOpportunityRelationshipEdit',
+                    'recordId' => '90d6129c-2a2b-4160-804e-f16ebe230443',
+                    'modern' => [
+                        'enabled' => true,
+                        'roleField' => 'opportunity_role'
+                    ],
+                    'values' => [
+                        'opportunity_role' => 'Primary Decision Maker'
+                    ],
+                    'fallbackToRecordEdit' => true
+                ]
+            ]
+        ]);
+
+        $service->run($process);
+
+        static::assertSame(['reload' => true], $process->getData());
+        static::assertSame('success', $process->getStatus());
+        static::assertSame([], $process->getMessages());
+    }
+
+    /**
+     * Regression: modern relation save failure should return action error.
+     */
+    public function testModernRelationshipEditReturnsErrorWhenSaveFails(): void
+    {
+        $service = new class($this->moduleNameMapper, $this->tester->getLegacyDir()) extends EditAction {
+            protected function saveOpportunityContactRole(string $relationshipRecordId, string $contactRole): bool
+            {
+                return false;
+            }
+        };
+
+        $process = new Process();
+        $process->setType('record-edit');
+        $process->setOptions([
+            'action' => 'record-edit',
+            'id' => '19b870a2-8d0b-4f4b-9116-67b5e501590f',
+            'module' => 'contacts',
+            'payload' => [
+                'baseModule' => 'opportunities',
+                'baseRecordId' => 'b641b285-1f5e-47a3-8a8d-0508aa20c2b1',
+                'linkField' => 'contacts',
+                'recordModule' => 'contacts',
+                'relationshipEdit' => [
+                    'enabled' => true,
+                    'module' => 'contacts',
+                    'action' => 'ContactOpportunityRelationshipEdit',
+                    'recordId' => '90d6129c-2a2b-4160-804e-f16ebe230443',
+                    'modern' => [
+                        'enabled' => true,
+                        'roleField' => 'opportunity_role'
+                    ],
+                    'values' => [
+                        'opportunity_role' => 'Primary Decision Maker'
+                    ],
+                    'fallbackToRecordEdit' => true
+                ]
+            ]
+        ]);
+
+        $service->run($process);
+
+        static::assertNull($process->getData());
+        static::assertSame('error', $process->getStatus());
+        static::assertSame(['LBL_ACTION_ERROR'], $process->getMessages());
     }
 }


### PR DESCRIPTION
## Summary
- add modern UI support for Opportunity -> Contacts relationship role editing (contact role)
- map `SubPanelEditRoleButton` to a field-modal config for this relationship
- pass selected role value in `relationshipEdit.values` payload
- handle modern relationship-save in backend `EditAction` and return `reload=true`
- add unit regression tests for modern save success and failure paths

## Dependency
This PR is a follow-up to #884 and depends on it.

Because GitHub does not allow setting a fork branch as upstream base, this branch is stacked on top of #884. So while #884 is still open, this PR diff will include parent changes from #884 as well.

## Related
- Related to #100
- Follow-up to #884
