### PR TITLE
Fix #699 - Employees link displayed but access denied for non-admin users

### DIFF
--- a/public/legacy/modules/ACL/ACLController.php
+++ b/public/legacy/modules/ACL/ACLController.php
@@ -112,6 +112,13 @@ class ACLController
                     $in_group
                 );
         }
+        // Employees has no acl_actions records — grant access unconditionally,
+        // matching legacy (Suite 7) behavior where Employees bypasses ACL entirely.
+        // Controller-level guards still enforce edit-own-only and delete-admin-only.
+        if ($category === 'Employees') {
+            return true;
+        }
+
         if ($category === 'Activities') {
             return ACLAction::userHasAccess(
                 $current_user->id,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

Fixes #699

Non-admin users could see the Employees link in the profile menu but were denied access when clicking it. This fix grants unconditional ACL access to the Employees module, matching legacy (Suite 7) behavior.

In legacy, the Employees module has no ACL integration — `Employee.php` does not implement `bean_implements('ACL')`, has no `acl_actions` records, and access is always granted. In SuiteCRM 8, `UserACLHandler` blocks non-admin users because `ACLAction::userHasAccess()` fails when no `acl_actions` records exist for the module.

The fix adds an Employees special case in `ACLController::checkAccess()` that returns `true` unconditionally, following the same delegation pattern already used by Calendar, Activities, and AOS_Products_Quotes in the same method.

Existing controller-level guards remain unchanged and continue to enforce:
- **Edit**: own record only (`controller.php:52-60`)
- **Delete**: admin only (`controller.php:62-77`)
- **Save**: own record only (`Employee.php:304-326`)
- **Export**: admin only (`Employee.php:188-220`)
- **Create**: admin only (`Menu.php:56-58`)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

In legacy SuiteCRM, all users can see the Employees list and view employee records — restrictions only apply to editing (own record) and deleting (admin only). SuiteCRM 8's ACL framework introduced an unintended regression by denying access entirely to non-admin users, since the Employees module was never designed to have ACL records.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

1. Log in as a **non-admin** user
2. Click on the user profile menu (top-right)
3. **Expected:** "Employees" link is visible
4. Click the "Employees" link
5. **Expected:** The Employees list view loads and shows all employee records
6. Click on an employee record
7. **Expected:** The detail view loads successfully
8. Try to edit another user's employee record
9. **Expected:** Access denied (only own record is editable)
10. Log in as **admin** and repeat steps 2-7
11. **Expected:** Admin can see and edit all employee records

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.