### PR TITLE
Fix #902 - Multienum fields return null values due to PrimeNG 17.18.15 regression

### DIFF
--- a/core/app/core/src/lib/fields/base/base-multienum.component.ts
+++ b/core/app/core/src/lib/fields/base/base-multienum.component.ts
@@ -61,7 +61,9 @@ export class BaseMultiEnumComponent extends BaseEnumComponent {
     protected updateInternalState(value: string | string[] = []): void {
         const valueArray = isArray(value) ? value : [value];
 
-        this.selectedValues = valueArray.map(valueElement=>this.buildOptionFromValue(valueElement, ''));
+        this.selectedValues = valueArray
+            .filter(v => !isVoid(v) && v !== '')
+            .map(valueElement => this.buildOptionFromValue(valueElement, ''));
         this.selectedValues = uniqBy(this.selectedValues, 'value');
 
         this.syncSelectedValuesWithForm();

--- a/core/app/core/src/lib/fields/multienum/templates/edit/multienum.component.html
+++ b/core/app/core/src/lib/fields/multienum/templates/edit/multienum.component.html
@@ -31,6 +31,7 @@
         [options]="options"
         [(ngModel)]="selectedValues"
         [optionLabel]="'label'"
+        [optionValue]="'value'"
         (onChange)="onAdd()"
         (onSelectAllChange)="onSelectAll($event)"
         (onRemove)="onRemove()"

--- a/core/app/core/src/lib/fields/multienum/templates/edit/multienum.component.ts
+++ b/core/app/core/src/lib/fields/multienum/templates/edit/multienum.component.ts
@@ -64,6 +64,14 @@ export class MultiEnumEditFieldComponent extends BaseMultiEnumComponent {
         super(languages, typeFormatter, logic, logicDisplay);
     }
 
+    protected initValue(): void {
+        super.initValue();
+        // Convert Option objects to value strings for PrimeNG [optionValue]="'value'" binding
+        this.selectedValues = (this.selectedValues ?? []).map(v =>
+            typeof v === 'string' ? v : v.value
+        ) as any;
+    }
+
     ngOnInit(): void {
         this.checkAndInitAsDynamicEnum();
         this.getTranslatedLabels();
@@ -86,7 +94,7 @@ export class MultiEnumEditFieldComponent extends BaseMultiEnumComponent {
     }
 
     public onAdd(): void {
-        const value = this.selectedValues.map(option => option.value);
+        const value = this.getSelectedValuesList();
         this.field.valueList = value;
         this.field.formControl.setValue(value);
         this.field.formControl.markAsDirty();
@@ -98,9 +106,9 @@ export class MultiEnumEditFieldComponent extends BaseMultiEnumComponent {
         this.selectAll = event.checked;
         if (this.selectAll) {
             if (this.multiSelect.visibleOptions() && this.multiSelect.visibleOptions().length) {
-                this.selectedValues = this.multiSelect.visibleOptions();
+                this.selectedValues = this.multiSelect.visibleOptions().map(option => option.value) as any;
             } else {
-                this.selectedValues = this.options;
+                this.selectedValues = this.options.map(option => option.value) as any;
             }
             this.onAdd();
         } else {
@@ -110,8 +118,7 @@ export class MultiEnumEditFieldComponent extends BaseMultiEnumComponent {
     }
 
     public onRemove(): void {
-
-        const value = this.selectedValues.map(option => option.value);
+        const value = this.getSelectedValuesList();
         this.field.valueList = value;
         this.field.formControl.setValue(value);
         this.field.formControl.markAsDirty();
@@ -141,9 +148,15 @@ export class MultiEnumEditFieldComponent extends BaseMultiEnumComponent {
         this.emptyFilterLabel = this.languages.getAppString('ERR_SEARCH_NO_RESULTS') || '';
     }
 
+    protected getSelectedValuesList(): string[] {
+        return (this.selectedValues ?? []).map(item =>
+            typeof item === 'string' ? item : item.value
+        );
+    }
+
     protected calculateSelectAll(): void {
         const visibleOptions = this?.multiSelect?.visibleOptions() ?? [];
-        const selectedValuesKeys = (this?.selectedValues ?? []).map(item => item.value);
+        const selectedValuesKeys = this.getSelectedValuesList();
 
         if (!visibleOptions.length || !selectedValuesKeys.length) {
             this.selectAll = false;

--- a/core/app/core/src/lib/fields/multienum/templates/filter/multienum.component.html
+++ b/core/app/core/src/lib/fields/multienum/templates/filter/multienum.component.html
@@ -31,6 +31,7 @@
         [options]="options"
         [(ngModel)]="selectedValues"
         [optionLabel]="'label'"
+        [optionValue]="'value'"
         (onChange)="onAdd()"
         (onSelectAllChange)="onSelectAll($event)"
         (onRemove)="onRemove()"

--- a/core/app/core/src/lib/fields/multienum/templates/filter/multienum.component.ts
+++ b/core/app/core/src/lib/fields/multienum/templates/filter/multienum.component.ts
@@ -62,6 +62,13 @@ export class MultiEnumFilterFieldComponent extends BaseMultiEnumComponent implem
         super(languages, typeFormatter, logic, logicDisplay);
     }
 
+    protected initValue(): void {
+        super.initValue();
+        this.selectedValues = (this.selectedValues ?? []).map(v =>
+            typeof v === 'string' ? v : v.value
+        ) as any;
+    }
+
     ngOnInit(): void {
         this.field.valueList = [];
 
@@ -82,9 +89,14 @@ export class MultiEnumFilterFieldComponent extends BaseMultiEnumComponent implem
         this.primengConfig.ripple = true;
     }
 
-    public onAdd(): void {
+    protected getSelectedValuesList(): string[] {
+        return (this.selectedValues ?? []).map(item =>
+            typeof item === 'string' ? item : item.value
+        );
+    }
 
-        const value = this.selectedValues.map(option => option.value);
+    public onAdd(): void {
+        const value = this.getSelectedValuesList();
         this.field.valueList = value;
         this.field.formControl.setValue(value);
         this.field.formControl.markAsDirty();
@@ -95,8 +107,7 @@ export class MultiEnumFilterFieldComponent extends BaseMultiEnumComponent implem
     }
 
     public onRemove(): void {
-
-        let value = this.selectedValues.map(option => option.value);
+        let value = this.getSelectedValuesList();
         if (!value) {
             value = [];
         }
@@ -134,11 +145,10 @@ export class MultiEnumFilterFieldComponent extends BaseMultiEnumComponent implem
     public onSelectAll(event): void {
         this.selectAll = event.checked;
         if (this.selectAll) {
-
             if (this.multiSelect.visibleOptions() && this.multiSelect.visibleOptions().length) {
-                this.selectedValues = this.multiSelect.visibleOptions();
+                this.selectedValues = this.multiSelect.visibleOptions().map(option => option.value) as any;
             } else {
-                this.selectedValues = this.options;
+                this.selectedValues = this.options.map(option => option.value) as any;
             }
             this.onAdd();
         } else {
@@ -159,7 +169,7 @@ export class MultiEnumFilterFieldComponent extends BaseMultiEnumComponent implem
 
     protected calculateSelectAll(): void {
         const visibleOptions = this?.multiSelect?.visibleOptions() ?? [];
-        const selectedValuesKeys = (this?.selectedValues ?? []).map(item => item.value);
+        const selectedValuesKeys = this.getSelectedValuesList();
 
         if (!visibleOptions.length || !selectedValuesKeys.length) {
             this.selectAll = false;


### PR DESCRIPTION
## Summary

- PrimeNG 17.18.15 (upgraded from 17.18.11 in 8.9.3) changed `getOptionValue()` to check `!this.optionLabel` instead of `!this.optionValue`
- Since SuiteCRM sets `[optionLabel]="'label'"` but not `[optionValue]`, the multiselect model binding broke — selected options mapped to `null` instead of their key values
- This caused corrupted database entries (`^^,^^`) and null displays in edit/filter views

## Changes

- Add explicit `[optionValue]="'value'"` to multiselect templates (edit + filter)
- Add `initValue()` overrides in edit/filter components to convert Option objects to value strings for PrimeNG binding
- Update `onAdd()`, `onRemove()`, `onSelectAll()`, and `calculateSelectAll()` to handle string values
- Filter empty/null values in `base-multienum.component.ts` to prevent corrupted data propagation

## Files Changed

- `core/app/core/src/lib/fields/base/base-multienum.component.ts`
- `core/app/core/src/lib/fields/multienum/templates/edit/multienum.component.html`
- `core/app/core/src/lib/fields/multienum/templates/edit/multienum.component.ts`
- `core/app/core/src/lib/fields/multienum/templates/filter/multienum.component.html`
- `core/app/core/src/lib/fields/multienum/templates/filter/multienum.component.ts`

## Test plan

- [ ] Select items in a multienum field in edit view → verify correct values saved
- [ ] Verify multienum detail view displays labels correctly
- [ ] Verify multienum filter works correctly with selections
- [ ] Verify select-all works in multiselect dropdowns
- [ ] Verify clearing selections works

Fixes #902

🤖 Generated with [Claude Code](https://claude.com/claude-code)