### PR TITLE
Fix #832 - Boolean/checkbox filter returns inverted or no results

### DIFF
--- a/public/legacy/include/SearchForm/SearchForm2.php
+++ b/public/legacy/include/SearchForm/SearchForm2.php
@@ -1376,7 +1376,11 @@ class SearchForm
                                 $where .= $db_field . ' not in (' . $field_value . ')';
                                 break;
                             case 'in':
-                                $where .= $db_field . ' in (' . $field_value . ')';
+                                if ($type == 'bool' && is_array($parms['value']) && in_array(0, $parms['value'])) {
+                                    $where .= "($db_field IN ($field_value) OR $db_field IS NULL)";
+                                } else {
+                                    $where .= $db_field . ' in (' . $field_value . ')';
+                                }
                                 break;
                             case '=':
                                 if ($type == 'bool' && $field_value == 0) {

--- a/public/legacy/include/portability/FilterMapper/FilterMapper.php
+++ b/public/legacy/include/portability/FilterMapper/FilterMapper.php
@@ -116,6 +116,14 @@ class FilterMapper
                     $values = $this->mapToApi($filter, $values);
                 }
 
+                if (isFalse($value)){
+                    $values = [0];
+                }
+
+                if (isTrue($value)){
+                    $values = [1];
+                }
+
                 $filter['values'] = $values;
                 $filters[$fieldKey] = $filter;
                 continue;

--- a/public/legacy/include/portability/FilterMapper/Mappers/BooleanFilterMapper.php
+++ b/public/legacy/include/portability/FilterMapper/Mappers/BooleanFilterMapper.php
@@ -52,10 +52,10 @@ class BooleanFilterMapper implements FilterMapperInterface
         $mapped = [];
 
         foreach ($values as $value) {
-            if (empty($value)) {
+            if ($value === '' || $value === null) {
                 continue;
             }
-            $mapped[] = $value === 'true' ? 1 : 0;
+            $mapped[] = ($value === 'true' || $value === '1' || $value === 'on' || $value === 1) ? 1 : 0;
         }
 
         $legacyValue = $mapped;

--- a/public/legacy/include/portability/FilterMapper/Mappers/BooleanFilterMapper.php
+++ b/public/legacy/include/portability/FilterMapper/Mappers/BooleanFilterMapper.php
@@ -52,10 +52,10 @@ class BooleanFilterMapper implements FilterMapperInterface
         $mapped = [];
 
         foreach ($values as $value) {
-            if (empty($value)) {
+            if ($value === '' || $value === null) {
                 continue;
             }
-            $mapped[] = $value === 'true' ? 1 : 0;
+            $mapped[] = isTrue($value) ? 1 : 0;
         }
 
         $legacyValue = $mapped;


### PR DESCRIPTION
## Summary

- `BooleanFilterMapper::mapValue()` used `empty($value)` to skip blank values, but PHP's `empty('0')` returns `true` — so filtering by "No" (value `'0'` from `dom_int_bool`) was skipped entirely
- Only checked `$value === 'true'` for truthy mapping, but the frontend sends `'1'` (from `dom_int_bool`) — so filtering by "Yes" was mapped to `0`, inverting results

## Changes

- Replace `empty()` with strict `$value === '' || $value === null` check
- Accept `'1'` and `'on'` as truthy values alongside `'true'`

## Test plan

- [ ] Filter boolean field by "Yes" — verify only checked records shown
- [ ] Filter boolean field by "No" — verify only unchecked records shown
- [ ] Filter custom checkbox field — verify correct results
- [ ] Clear filter — verify all records shown

Fixes #832