### PR TITLE
Feat #909 - Add DocumentRevision file upload support to V8 API

### DIFF
--- a/public/legacy/Api/V8/Service/ModuleService.php
+++ b/public/legacy/Api/V8/Service/ModuleService.php
@@ -277,6 +277,9 @@ class ModuleService
         if ($fileUpload && $bean->module_dir === 'Notes') {
             $this->addFileToNote($bean->id, $attributes);
         }
+        if ($fileUpload && $bean->module_dir === 'DocumentRevisions') {
+            $this->addFileToDocumentRevision($bean->id, $attributes);
+        }
         if ($fileUpload && $bean->module_dir === 'Documents') {
             $this->addFileToDocument($bean, $attributes);
         }
@@ -359,6 +362,57 @@ class ModuleService
         }
         $Revision->save();
         $bean->document_revision_id = $Revision->id;
+        $bean->save();
+    }
+
+    /**
+     * @param $beanId
+     * @param $attributes
+     * @throws Exception
+     */
+    protected function addFileToDocumentRevision($beanId, $attributes)
+    {
+        global $sugar_config, $log;
+
+        $module = 'DocumentRevision';
+        if (!empty($attributes['moduleName'])) {
+            $module = $attributes['moduleName'];
+            unset($attributes['moduleName']);
+        }
+        BeanFactory::unregisterBean($module, $beanId);
+        $bean = $this->beanManager->getBeanSafe($module, $beanId);
+
+        // Write file to upload dir
+        try {
+            // Checking file extension
+            $extPos = strrpos((string) $attributes['filename'], '.');
+            $fileExtension = substr((string) $attributes['filename'], $extPos + 1);
+
+            if ($extPos === false || empty($fileExtension) || in_array(
+                    $fileExtension,
+                    $sugar_config['upload_badext'],
+                    true
+                )) {
+                throw new Exception('File upload failed: File extension is not included or is not valid.');
+            }
+
+            $fileName = $bean->id;
+            $fileContents = $attributes['filecontents'];
+            $targetPath = 'upload/' . $fileName;
+            $content = base64_decode($fileContents);
+
+            $file = fopen($targetPath, 'wb');
+            fwrite($file, $content);
+            fclose($file);
+        } catch (Exception $e) {
+            $log->error('addFileToDocumentRevision: ' . $e->getMessage());
+            throw new Exception($e->getMessage());
+        }
+
+        // Fill in file details for use with upload checks
+        $mimeType = mime_content_type($targetPath);
+        $bean->filename = $attributes['filename'];
+        $bean->file_mime_type = $mimeType;
         $bean->save();
     }
 

--- a/public/legacy/modules/DocumentRevisions/vardefs.php
+++ b/public/legacy/modules/DocumentRevisions/vardefs.php
@@ -229,7 +229,14 @@ $dictionary['DocumentRevision'] = array('table' => 'document_revisions'
       'len' => '255',
       'source' => 'non-db',
   ),
-  
+  'filecontents' =>
+  array(
+       'name' => 'filecontents',
+       'vname' => 'LBL_FILE_CONTENTS',
+       'type' => 'varchar',
+       'source' => 'non-db',
+  ),
+
 ),
 'relationships'=>array(
    'revisions_created_by' => array('lhs_module'=> 'Users', 'lhs_table'=> 'users', 'lhs_key' => 'id',


### PR DESCRIPTION
## Summary

- V8 API `createRecord()` only handled file uploads for Notes and Documents, not DocumentRevisions
- Added `addFileToDocumentRevision()` method following the same pattern as `addFileToNote()`
- Added virtual `filecontents` field to DocumentRevisions vardefs so the API accepts file content

## Test plan

- [ ] Create a DocumentRevision via V8 API with `filename` and `filecontents` attributes
- [ ] Verify file is written to `upload/` directory
- [ ] Verify `filename` and `file_mime_type` are set on the bean
- [ ] Verify existing Notes and Documents file uploads still work

Closes #909 