### PR TITLE
Feat #907 - Allow inline preview of file attachments in browser

### DIFF
--- a/public/legacy/download.php
+++ b/public/legacy/download.php
@@ -274,7 +274,8 @@ if ((!isset($_REQUEST['isProfile']) && empty($_REQUEST['id'])) || empty($_REQUES
             }
 
             if (!empty($row['file_ext']) && in_array($row['file_ext'], $allowedPreview, true)) {
-                $showPreview = isset($_REQUEST['preview']) && $_REQUEST['preview'] === 'yes' && $mime_type !== 'text/html';
+                // Always preview when allowed, but never inline HTML
+                $showPreview = ($mime_type !== 'text/html');
             }
 
             if ($showPreview === true) {


### PR DESCRIPTION
## Summary

- `download.php` previously required `&preview=yes` URL parameter to show files inline
- Changed to automatically use `Content-Disposition: inline` for any file type listed in `$sugar_config['allowed_preview']`
- Backwards-compatible: without the config, all files download as before

## Configuration

Add to `config_override.php`:
```php
\$sugar_config['allowed_preview'] = ['gif', 'png', 'jpg', 'jpeg', 'pdf'];
```

## Test plan

- [ ] Configure allowed_preview with PDF and image extensions
- [ ] Click a PDF attachment — verify it opens inline in browser
- [ ] Click an image attachment — verify it opens inline
- [ ] Click a non-listed file type (e.g. .zip) — verify it downloads
- [ ] Without config set — verify all files download as before

Fixes #907