### PR TITLE
Restore deprecated getReleaseDropDown() in Bugs module

### DIFF
--- a/public/legacy/modules/Bugs/Bug.php
+++ b/public/legacy/modules/Bugs/Bug.php
@@ -384,3 +384,27 @@ class Bug extends SugarBean
         return parent::save($check_notify);
     }
 }
+
+/**
+ * Returns an associative array of active releases for dropdown use.
+ *
+ * @deprecated Release fields now use relate type with
+ *             direct module lookup. This function is kept only for backward
+ *             compatibility during upgrades and will be removed in a future
+ *             major version.
+ *
+ * @return array
+ */
+function getReleaseDropDown()
+{
+    LoggerManager::getLogger()->deprecated(
+        'getReleaseDropDown() is deprecated. Use relate fields for release selection instead.'
+    );
+
+    static $releases = null;
+    if (!$releases) {
+        $seedRelease = BeanFactory::newBean('Releases');
+        $releases = $seedRelease->get_releases(true, "Active");
+    }
+    return $releases;
+}

--- a/public/legacy/tests/unit/phpunit/modules/Bugs/BugTest.php
+++ b/public/legacy/tests/unit/phpunit/modules/Bugs/BugTest.php
@@ -208,4 +208,12 @@ class BugTest extends SuitePHPUnitFrameworkTestCase
         $result = $bug->retrieve($bug->id);
         self::assertEquals(null, $result);
     }
+
+    public function testgetReleaseDropDown(): void
+    {
+        $result = getReleaseDropDown();
+
+        //execute the method and verify it returns an array
+        self::assertIsArray($result);
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->
The function was removed in 83047c34 but is still called during upgrades, causing a fatal error. Re-add it with a @deprecated annotation and a runtime deprecation log so usage is visible in suitecrm.log. Will be removed in a future major version.

Restores the corresponding unit test as well.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
See description

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [ ] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->