### PR TITLE
Prevent retrieval of soft-deleted schedulers resulting in TypeError, stopping all schedulers from being run

### DIFF
--- a/core/backend/Schedulers/LegacyHandler/SchedulerHandler.php
+++ b/core/backend/Schedulers/LegacyHandler/SchedulerHandler.php
@@ -112,7 +112,7 @@ class SchedulerHandler extends LegacyHandler
         $schedulerTable = $this->getSchedulerTable();
         $jobQueueTable = $this->getJobQueueTable();
 
-        $query = "SELECT * FROM $schedulerTable sched WHERE status = 'Active' ";
+        $query = "SELECT * FROM $schedulerTable sched WHERE status = 'Active' AND deleted = 0 ";
         $query .= "AND NOT EXISTS(SELECT id FROM $jobQueueTable WHERE scheduler_id = sched.id AND status != 'done')";
         $schedulers = [];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

When a scheduler row is soft-deleted and `Active`, it is still retrieved by the SQL query in `SchedulerHandler.php`. The following call to `BeanFactory::getBean` results a boolean instead of a `SugarBean`, since it cannot find the Bean. Then a TypeError occurs in `createJob($schedulerBean)`: `Argument #1 ($scheduler) must be of type SugarBean, bool given`.

This results in all scheduled jobs being stuck in a `queued` state, as it aborts the whole handling of scheduled jobs, even if only one row is affected like that.

We fixed it by setting the soft-deleted scheduler also to `Inactive`. However a fix in the code to prevent retrieving soft-deleted records here should prevent this in the future as well.

Steps to reproduce:

- Soft-delete a scheduler, i.e. set the `deleted` column to `1`.
- Run `php bin/console schedulers:run`
- Observe error:

```
PHP Fatal error:  Uncaught TypeError: App\Schedulers\LegacyHandler\SchedulerHandler::createJob(): Argument #1 ($scheduler) must be of type SugarBean, bool given, called in /var/www/crm/core/backend/Schedulers/LegacyHandler/SchedulerHandler.php on line 136 and defined in /var/www/crm/core/backend/Schedulers/LegacyHandler/SchedulerHandler.php:388
Stack trace:
#0 /var/www/crm/core/backend/Schedulers/LegacyHandler/SchedulerHandler.php(136): App\Schedulers\LegacyHandler\SchedulerHandler->createJob()
#1 /var/www/crm/core/backend/Schedulers/Command/RunSchedulersCommand.php(102): App\Schedulers\LegacyHandler\SchedulerHandler->runSchedulers()
#2 /var/www/crm/core/backend/Schedulers/Command/RunSchedulersCommand.php(90): App\Schedulers\Command\RunSchedulersCommand->runSchedulers()
#3 /var/www/crm/core/backend/Install/Command/BaseCommand.php(185): App\Schedulers\Command\RunSchedulersCommand->executeCommand()
#4 /var/www/crm/vendor/symfony/console/Command/Command.php(326): App\Install\Command\BaseCommand->execute()
#5 /var/www/crm/vendor/symfony/console/Application.php(1106): Symfony\Component\Console\Command\Command->run()
#6 /var/www/crm/vendor/symfony/framework-bundle/Console/Application.php(126): Symfony\Component\Console\Application->doRunCommand()
#7 /var/www/crm/vendor/symfony/console/Application.php(324): Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand()
#8 /var/www/crm/vendor/symfony/framework-bundle/Console/Application.php(80): Symfony\Component\Console\Application->doRun()
#9 /var/www/crm/vendor/symfony/console/Application.php(175): Symfony\Bundle\FrameworkBundle\Console\Application->doRun()
#10 /var/www/crm/bin/console(42): Symfony\Component\Console\Application->run()
#11 {main}
  thrown in /var/www/crm/core/backend/Schedulers/LegacyHandler/SchedulerHandler.php on line 388
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Preventing soft-deleted schedulers stopping all schedulers from being run.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

See "Steps to reproduce" above.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->