### PR TITLE
Fix localstorage miss being interpreted as hit in language store

### DIFF
--- a/core/app/core/src/lib/store/language/language.store.ts
+++ b/core/app/core/src/lib/store/language/language.store.ts
@@ -370,7 +370,7 @@ export class LanguageStore implements StateStore {
 
         const storedLanguage = this.localStorage.get('selected_language');
 
-        if (storedLanguage) {
+        if (typeof storedLanguage === 'string' && storedLanguage !== '') {
             return storedLanguage;
         }
 
@@ -393,7 +393,8 @@ export class LanguageStore implements StateStore {
      * @returns {string} selected language key
      */
     public getSelectedLanguage(): string {
-        return this.localStorage.get('selected_language') ?? '';
+        const storedLanguage = this.localStorage.get('selected_language');
+        return (typeof storedLanguage === 'string' && storedLanguage !== '') ? storedLanguage : '';
     }
 
     /**


### PR DESCRIPTION
## Description

`getCurrentLanguage` and `getSelectedLanguage` in `language.store.ts` use the `LocalStorageService` (`local-storage.service.ts`) to get a language. However its `get` method returns `{}` on a miss. The language store assumes a falsy result on a miss, but `{}` is interpreted as truthy. This results in `getCurrentLanguage` returning this empty object instead of the default language. Also in `getSelectedLanguage` the fallback was never executed.



<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here unless your commit contains the issue number -->
<!--- Ensure that all code ``` is surrounded ``` by triple back quotes. This can also be done over multiple lines -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

For us this sometimes manifested as no selected active language in the language picker in a fresh browser session, which resulted in some `LBL_` keys being shown instead of translations.

Only actively selecting a language in the language picker fixed the issue.

## How To Test This
<!--- Please describe in detail how to test your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->